### PR TITLE
fix #16: works/steps API をバックエンドに配線

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,3 +1,5 @@
+version: "2"
+
 run:
   go: "1.24"
 
@@ -7,9 +9,10 @@ linters:
     - govet
     - staticcheck
     - unused
-    - gosimple
     - ineffassign
-    - typecheck
+
+formatters:
+  enable:
     - gofumpt
 
 issues:

--- a/backend/cmd/urushi-chronicle/main.go
+++ b/backend/cmd/urushi-chronicle/main.go
@@ -4,6 +4,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"strings"
 	"time"
 
 	"github.com/akaitigo/urushi-chronicle/internal/alert"
@@ -12,6 +13,7 @@ import (
 	"github.com/akaitigo/urushi-chronicle/internal/monitor"
 	"github.com/akaitigo/urushi-chronicle/internal/mqtt"
 	"github.com/akaitigo/urushi-chronicle/internal/repository"
+	"github.com/akaitigo/urushi-chronicle/internal/storage"
 	"github.com/google/uuid"
 )
 
@@ -21,6 +23,8 @@ func main() {
 	// Initialize repositories
 	envRepo := repository.NewMemoryEnvironmentRepository()
 	thresholdRepo := repository.NewMemoryAlertThresholdRepository()
+	workRepo := repository.NewMemoryWorkRepository()
+	stepRepo := repository.NewMemoryStepRepository()
 
 	// Initialize alert notifier (webhook URL from env; empty = no-op)
 	webhookURL := os.Getenv("ALERT_WEBHOOK_URL")
@@ -44,6 +48,21 @@ func main() {
 	}
 	thresholdRepo.Seed(defaultThreshold)
 
+	// Seed a default demo work for the frontend
+	demoWorkID := uuid.MustParse("00000000-0000-0000-0000-000000000001")
+	demoWork := &domain.Work{
+		ID:          demoWorkID,
+		Title:       "蒔絵香合 — 秋草",
+		Description: "秋草文様の蒔絵を施した香合。研出蒔絵技法を用いた習作。",
+		Technique:   domain.TechniqueMakie,
+		Material:    "欅",
+		Status:      domain.WorkStatusInProgress,
+		StartedAt:   now,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	workRepo.Seed(demoWork)
+
 	// Initialize MQTT subscriber (topic from env or default)
 	mqttTopic := os.Getenv("MQTT_TOPIC")
 	if mqttTopic == "" {
@@ -53,11 +72,26 @@ func main() {
 
 	// Initialize HTTP handlers
 	envHandler := handler.NewEnvironmentHandler(envRepo, thresholdRepo, monitorSvc)
+	bucketName := os.Getenv("GCS_BUCKET")
+	uploader := storage.NewGCSUploader(bucketName)
+	workHandler := handler.NewWorkHandler(workRepo)
+	stepHandler := handler.NewStepHandler(stepRepo, workRepo, uploader)
 
 	// Register routes
 	mux := http.NewServeMux()
 	mux.HandleFunc("/health", handler.HealthHandler())
 	mux.Handle("/api/v1/environment/", envHandler)
+
+	// /api/v1/works/ prefix: dispatch to StepHandler when path contains "/steps",
+	// otherwise delegate to WorkHandler for single-work lookups.
+	mux.HandleFunc("/api/v1/works/", func(w http.ResponseWriter, r *http.Request) {
+		if strings.Contains(r.URL.Path, "/steps") {
+			stepHandler.ServeHTTP(w, r)
+		} else {
+			workHandler.ServeHTTP(w, r)
+		}
+	})
+	mux.Handle("/api/v1/works", workHandler) // exact match: works list
 
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/backend/internal/alert/notifier.go
+++ b/backend/internal/alert/notifier.go
@@ -87,7 +87,7 @@ func (n *WebhookNotifier) Notify(reading domain.EnvironmentReading, threshold do
 	if err != nil {
 		return fmt.Errorf("failed to send alert webhook: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		return fmt.Errorf("alert webhook returned status %d", resp.StatusCode)

--- a/backend/internal/handler/work_handler.go
+++ b/backend/internal/handler/work_handler.go
@@ -1,0 +1,81 @@
+package handler
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/akaitigo/urushi-chronicle/internal/repository"
+	"github.com/google/uuid"
+)
+
+// WorkHandler handles HTTP requests for work (lacquerware piece) endpoints.
+type WorkHandler struct {
+	workRepo repository.WorkRepository
+}
+
+// NewWorkHandler creates a new WorkHandler with the given repository.
+func NewWorkHandler(workRepo repository.WorkRepository) *WorkHandler {
+	return &WorkHandler{workRepo: workRepo}
+}
+
+// ServeHTTP routes requests to the appropriate handler method.
+// Expected paths:
+//   - GET /api/v1/works          — list all works
+//   - GET /api/v1/works/{id}     — get a single work by ID
+func (h *WorkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		w.Header().Set("Allow", "GET")
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+
+	const prefix = "/api/v1/works"
+	path := strings.TrimPrefix(r.URL.Path, prefix)
+	path = strings.TrimPrefix(path, "/")
+
+	if path == "" {
+		h.listWorks(w)
+		return
+	}
+
+	// Reject paths with extra segments (e.g., /api/v1/works/{id}/something)
+	if strings.Contains(path, "/") {
+		writeError(w, http.StatusNotFound, "not found")
+		return
+	}
+
+	id, err := uuid.Parse(path)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid work ID")
+		return
+	}
+	h.getWork(w, id)
+}
+
+func (h *WorkHandler) listWorks(w http.ResponseWriter) {
+	works, err := h.workRepo.FindAll()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "failed to list works")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]interface{}{
+		"items": works,
+		"total": len(works),
+	})
+}
+
+func (h *WorkHandler) getWork(w http.ResponseWriter, id uuid.UUID) {
+	work, err := h.workRepo.FindByID(id)
+	if err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "work not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get work")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, work)
+}

--- a/backend/internal/handler/work_handler_test.go
+++ b/backend/internal/handler/work_handler_test.go
@@ -1,0 +1,153 @@
+package handler_test
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/akaitigo/urushi-chronicle/internal/domain"
+	"github.com/akaitigo/urushi-chronicle/internal/handler"
+	"github.com/akaitigo/urushi-chronicle/internal/repository"
+	"github.com/google/uuid"
+)
+
+func setupWorkTest() (*handler.WorkHandler, *repository.MemoryWorkRepository) {
+	workRepo := repository.NewMemoryWorkRepository()
+	h := handler.NewWorkHandler(workRepo)
+	return h, workRepo
+}
+
+func seedWork(repo *repository.MemoryWorkRepository, title string) uuid.UUID {
+	id := uuid.New()
+	now := time.Now().UTC()
+	repo.Seed(&domain.Work{
+		ID:        id,
+		Title:     title,
+		Technique: domain.TechniqueMakie,
+		Status:    domain.WorkStatusInProgress,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+	return id
+}
+
+func TestListWorks_Empty(t *testing.T) {
+	h, _ := setupWorkTest()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	if err := json.Unmarshal(rr.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("failed to parse response: %v", err)
+	}
+	if resp["total"].(float64) != 0 {
+		t.Errorf("expected total 0, got %v", resp["total"])
+	}
+}
+
+func TestListWorks_WithData(t *testing.T) {
+	h, repo := setupWorkTest()
+	seedWork(repo, "蒔絵香合")
+	seedWork(repo, "螺鈿硯箱")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+
+	var resp map[string]interface{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp["total"].(float64) != 2 {
+		t.Errorf("expected total 2, got %v", resp["total"])
+	}
+	items := resp["items"].([]interface{})
+	if len(items) != 2 {
+		t.Errorf("expected 2 items, got %d", len(items))
+	}
+}
+
+func TestGetWork_Success(t *testing.T) {
+	h, repo := setupWorkTest()
+	id := seedWork(repo, "蒔絵香合")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works/"+id.String(), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp["title"] != "蒔絵香合" {
+		t.Errorf("expected title '蒔絵香合', got %v", resp["title"])
+	}
+}
+
+func TestGetWork_NotFound(t *testing.T) {
+	h, _ := setupWorkTest()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works/"+uuid.New().String(), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", rr.Code)
+	}
+}
+
+func TestGetWork_InvalidID(t *testing.T) {
+	h, _ := setupWorkTest()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works/not-a-uuid", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", rr.Code)
+	}
+}
+
+func TestWorkHandler_MethodNotAllowed(t *testing.T) {
+	h, _ := setupWorkTest()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/works", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rr.Code)
+	}
+}
+
+func TestListWorks_TrailingSlash(t *testing.T) {
+	h, repo := setupWorkTest()
+	seedWork(repo, "テスト作品")
+
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/works/", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]interface{}
+	_ = json.Unmarshal(rr.Body.Bytes(), &resp)
+	if resp["total"].(float64) != 1 {
+		t.Errorf("expected total 1, got %v", resp["total"])
+	}
+}

--- a/backend/internal/repository/memory_work.go
+++ b/backend/internal/repository/memory_work.go
@@ -33,6 +33,18 @@ func (r *MemoryWorkRepository) FindByID(id uuid.UUID) (*domain.Work, error) {
 	return &copied, nil
 }
 
+// FindAll retrieves all works from the repository.
+func (r *MemoryWorkRepository) FindAll() ([]domain.Work, error) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	result := make([]domain.Work, 0, len(r.works))
+	for _, w := range r.works {
+		result = append(result, *w)
+	}
+	return result, nil
+}
+
 // Seed adds a work to the repository (for testing/bootstrapping).
 func (r *MemoryWorkRepository) Seed(work *domain.Work) {
 	r.mu.Lock()

--- a/backend/internal/repository/memory_work_test.go
+++ b/backend/internal/repository/memory_work_test.go
@@ -39,6 +39,63 @@ func TestMemoryWorkRepository_FindByID_NotFound(t *testing.T) {
 	}
 }
 
+func TestMemoryWorkRepository_FindAll_Empty(t *testing.T) {
+	repo := repository.NewMemoryWorkRepository()
+	works, err := repo.FindAll()
+	if err != nil {
+		t.Fatalf("FindAll failed: %v", err)
+	}
+	if len(works) != 0 {
+		t.Errorf("expected 0 works, got %d", len(works))
+	}
+}
+
+func TestMemoryWorkRepository_FindAll_WithData(t *testing.T) {
+	repo := repository.NewMemoryWorkRepository()
+	now := time.Now().UTC()
+	for i := 0; i < 3; i++ {
+		repo.Seed(&domain.Work{
+			ID:        uuid.New(),
+			Title:     "作品",
+			Technique: domain.TechniqueMakie,
+			Status:    domain.WorkStatusInProgress,
+			StartedAt: now,
+			CreatedAt: now,
+			UpdatedAt: now,
+		})
+	}
+
+	works, err := repo.FindAll()
+	if err != nil {
+		t.Fatalf("FindAll failed: %v", err)
+	}
+	if len(works) != 3 {
+		t.Errorf("expected 3 works, got %d", len(works))
+	}
+}
+
+func TestMemoryWorkRepository_FindAll_ReturnsIndependentCopies(t *testing.T) {
+	repo := repository.NewMemoryWorkRepository()
+	now := time.Now().UTC()
+	repo.Seed(&domain.Work{
+		ID:        uuid.New(),
+		Title:     "オリジナル",
+		Technique: domain.TechniqueMakie,
+		Status:    domain.WorkStatusInProgress,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	works, _ := repo.FindAll()
+	works[0].Title = "変更後"
+
+	worksAgain, _ := repo.FindAll()
+	if worksAgain[0].Title != "オリジナル" {
+		t.Errorf("FindAll should return copies, got %q", worksAgain[0].Title)
+	}
+}
+
 func TestMemoryWorkRepository_Seed_ReturnsIndependentCopy(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 	work := &domain.Work{

--- a/backend/internal/repository/step_repository.go
+++ b/backend/internal/repository/step_repository.go
@@ -19,4 +19,5 @@ type StepRepository interface {
 // WorkRepository defines the interface for work persistence.
 type WorkRepository interface {
 	FindByID(id uuid.UUID) (*domain.Work, error)
+	FindAll() ([]domain.Work, error)
 }


### PR DESCRIPTION
## Summary
- frontend が呼び出す `GET /api/v1/works`, `GET /api/v1/works/{id}`, `GET /api/v1/works/{workId}/steps` が 404 を返していた問題を修正
- `WorkHandler` (一覧・詳細) を新規実装し、既存の `StepHandler` と共に `main.go` のルーティングに登録
- `WorkRepository` インターフェースに `FindAll()` を追加、`MemoryWorkRepository` に実装

## Changes
| File | What |
|------|------|
| `backend/internal/handler/work_handler.go` | 新規: GET /api/v1/works (一覧), GET /api/v1/works/{id} (詳細) |
| `backend/internal/handler/work_handler_test.go` | 新規: WorkHandler のユニットテスト (7テスト) |
| `backend/internal/repository/step_repository.go` | `WorkRepository` に `FindAll()` を追加 |
| `backend/internal/repository/memory_work.go` | `FindAll()` を実装 |
| `backend/internal/repository/memory_work_test.go` | `FindAll` のユニットテスト (3テスト追加) |
| `backend/cmd/urushi-chronicle/main.go` | WorkHandler/StepHandler のルーティング登録 + デモ作品 Seed |
| `.golangci.yml` | golangci-lint v2 設定フォーマットに移行 |
| `backend/internal/alert/notifier.go` | errcheck 違反修正 (resp.Body.Close) |

## Test plan
- [x] `make check` 全パス (lint 0 issues, backend 全テスト通過, frontend 45テスト通過, ビルド成功)
- [x] pre-commit フック全パス (archgate, format-check, lint, test)

Closes #16