### PR TITLE
chore: upgrade dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,11 +17,11 @@ jobs:
       run:
         working-directory: backend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: "1.24"
+          go-version-file: backend/go.mod
 
       - name: Build
         run: go build ./...
@@ -30,7 +30,7 @@ jobs:
         run: go test -v -race ./...
 
       - name: Lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v9
         with:
           version: latest
           working-directory: backend
@@ -42,7 +42,7 @@ jobs:
       run:
         working-directory: frontend
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v6
         with:

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.9/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.10/schema.json",
   "formatter": {
     "enabled": true,
     "indentStyle": "space",


### PR DESCRIPTION
## Summary
- Frontend: npm packages updated to latest patch versions
- Biome schema 2.4.9 → 2.4.10
- CI: actions/checkout v4 → v6
- CI: actions/setup-go v5 → v6 (go-version-file)
- CI: golangci-lint-action v6 → v9

## Test plan
- [x] `make check` passed locally (all tests green)