### PR TITLE
fix: DB接続用contextのcancel()スコープを修正

### DIFF
--- a/backend/cmd/urushi-chronicle/main.go
+++ b/backend/cmd/urushi-chronicle/main.go
@@ -65,9 +65,8 @@ func main() {
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), database.DefaultConnectTimeout)
-		defer cancel()
-
 		pool, err := database.NewPool(ctx, databaseURL)
+		cancel() // contextはDB接続確立後に不要なため即座にキャンセル
 		if err != nil {
 			logger.Fatalf("failed to connect to database: %v", err)
 		}


### PR DESCRIPTION
## Summary
- `defer cancel()` を `cancel()` 即座呼び出しに変更
- DB接続確立後はタイムアウト用contextが不要のため、NewPool直後にリソースを解放
- deferだとmain関数終了までcontextが不要に生存し続ける問題を修正

## Test plan
- [x] `go test ./...` 全パス
- [x] `go build ./...` 成功
- [x] lefthook pre-commit (lint, format, test) 全パス