### PR TITLE
fix: Work削除時のカスケード削除順序を修正

### DIFF
--- a/backend/internal/handler/work_handler.go
+++ b/backend/internal/handler/work_handler.go
@@ -220,6 +220,28 @@ func (h *WorkHandler) updateWork(w http.ResponseWriter, r *http.Request, id uuid
 }
 
 func (h *WorkHandler) deleteWork(w http.ResponseWriter, id uuid.UUID) {
+	// Verify work exists before attempting deletion.
+	if _, err := h.workRepo.FindByID(id); err != nil {
+		if errors.Is(err, repository.ErrNotFound) {
+			writeError(w, http.StatusNotFound, "work not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "failed to get work")
+		return
+	}
+
+	// Cascade: delete all associated process steps BEFORE the work itself.
+	// This prevents orphaned steps if the work deletion succeeds but step
+	// deletion would fail, and ensures correct ordering in in-memory mode
+	// (PostgreSQL handles this via ON DELETE CASCADE, but application-level
+	// ordering must also be correct for the in-memory store).
+	if h.stepRepo != nil {
+		if err := h.stepRepo.DeleteByWorkID(id); err != nil {
+			writeError(w, http.StatusInternalServerError, "failed to delete associated steps")
+			return
+		}
+	}
+
 	if err := h.workRepo.Delete(id); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
@@ -227,14 +249,6 @@ func (h *WorkHandler) deleteWork(w http.ResponseWriter, id uuid.UUID) {
 		}
 		writeError(w, http.StatusInternalServerError, "failed to delete work")
 		return
-	}
-
-	// Cascade: delete all associated process steps.
-	if h.stepRepo != nil {
-		if err := h.stepRepo.DeleteByWorkID(id); err != nil {
-			writeError(w, http.StatusInternalServerError, "failed to delete associated steps")
-			return
-		}
 	}
 
 	w.WriteHeader(http.StatusNoContent)

--- a/backend/internal/handler/work_handler_test.go
+++ b/backend/internal/handler/work_handler_test.go
@@ -325,6 +325,74 @@ func TestDeleteWork_NotFound(t *testing.T) {
 	}
 }
 
+// --- DELETE with cascade ---
+
+func TestDeleteWork_CascadeDeletesSteps(t *testing.T) {
+	workRepo := repository.NewMemoryWorkRepository()
+	stepRepo := repository.NewMemoryStepRepository()
+	h := handler.NewWorkHandler(workRepo, stepRepo)
+
+	workID := uuid.New()
+	now := time.Now().UTC()
+	workRepo.Seed(&domain.Work{
+		ID:        workID,
+		Title:     "カスケード削除テスト",
+		Technique: domain.TechniqueMakie,
+		Status:    domain.WorkStatusInProgress,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	// Seed a process step for the work
+	stepID := uuid.New()
+	if err := stepRepo.Create(&domain.ProcessStep{
+		ID:        stepID,
+		WorkID:    workID,
+		Name:      "下塗り",
+		StepOrder: 1,
+		Category:  domain.StepCategoryShitanuri,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}); err != nil {
+		t.Fatalf("failed to seed step: %v", err)
+	}
+
+	// Verify step exists before delete
+	steps, err := stepRepo.FindByWorkID(workID)
+	if err != nil {
+		t.Fatalf("failed to find steps: %v", err)
+	}
+	if len(steps) != 1 {
+		t.Fatalf("expected 1 step before delete, got %d", len(steps))
+	}
+
+	// Delete the work
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/works/"+workID.String(), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	// Verify work is deleted
+	_, err = workRepo.FindByID(workID)
+	if err == nil {
+		t.Error("expected work to be deleted, but FindByID returned no error")
+	}
+
+	// Verify steps are cascade-deleted
+	steps, err = stepRepo.FindByWorkID(workID)
+	if err != nil {
+		t.Fatalf("failed to find steps after delete: %v", err)
+	}
+	if len(steps) != 0 {
+		t.Errorf("expected 0 steps after cascade delete, got %d", len(steps))
+	}
+}
+
 // --- Method Not Allowed ---
 
 func TestWorkHandler_MethodNotAllowed_Collection(t *testing.T) {


### PR DESCRIPTION
## Summary
- Work削除時にProcessStepの削除順序が逆だった問題を修正
- Work本体を先に削除→Step削除の順序を、Step削除→Work削除に変更
- 削除前にWorkの存在確認を追加し、404レスポンスの正確性を向上
- カスケード削除の統合テストを追加

## 問題
`deleteWork`でWork本体を先に削除してからProcessStepを削除していたため、
インメモリモードでStep削除が失敗した場合に以下の不整合が発生する可能性があった:
- Workは削除済みなのに500エラーが返る
- ProcessStepが孤児として残る

## 修正内容
1. 削除前にWorkの存在確認（FindByID）を追加
2. ProcessStepを先に削除（DeleteByWorkID）
3. 成功後にWork本体を削除

## Test plan
- [x] `TestDeleteWork_CascadeDeletesSteps`: カスケード削除の統合テスト追加
- [x] 既存テスト全59件パス（Go + Frontend）
- [x] golangci-lint 0 issues
- [x] lefthook pre-commit全フック通過