### PR TITLE
ci: update actions/setup-go v5 to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - uses: actions/setup-go@v5
+      - uses: actions/setup-go@v6
         with:
           go-version-file: backend/go.mod
 


### PR DESCRIPTION
## 概要
actions/setup-go を v5 → v6 に更新する。

## 背景
#30 (Node.js 20 deprecation対応) の残作業。dependabot PR (#84/#42/#31) で checkout/fetch-metadata/setup-node は更新済みだが、setup-go@v5（Node 20 ランタイム）が残存していた。dependabot は setup-go の更新PRを未作成だったため手動対応。

## 検証
- actionlint パス

Refs #30