### PR TITLE
style(backend): gofumpt整形をrepository層に適用

### DIFF
--- a/backend/internal/repository/pg_alert_threshold.go
+++ b/backend/internal/repository/pg_alert_threshold.go
@@ -30,7 +30,8 @@ func (r *PgAlertThresholdRepository) Create(threshold *domain.AlertThreshold) er
 			 enabled, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)
 	`
-	_, err := r.pool.Exec(ctx, query,
+	_, err := r.pool.Exec(
+		ctx, query,
 		threshold.ID, threshold.SensorID,
 		threshold.TemperatureMin, threshold.TemperatureMax,
 		threshold.HumidityMin, threshold.HumidityMax,
@@ -150,7 +151,8 @@ func (r *PgAlertThresholdRepository) Update(threshold *domain.AlertThreshold) er
 		    humidity_min = $5, humidity_max = $6, enabled = $7, updated_at = $8
 		WHERE id = $1
 	`
-	tag, err := r.pool.Exec(ctx, query,
+	tag, err := r.pool.Exec(
+		ctx, query,
 		threshold.ID, threshold.SensorID,
 		threshold.TemperatureMin, threshold.TemperatureMax,
 		threshold.HumidityMin, threshold.HumidityMax,
@@ -210,7 +212,8 @@ func (r *PgAlertThresholdRepository) FindAndUpdate(id uuid.UUID, updateFn func(e
 		    humidity_min = $5, humidity_max = $6, enabled = $7, updated_at = $8
 		WHERE id = $1
 	`
-	_, err = tx.Exec(ctx, updateQuery,
+	_, err = tx.Exec(
+		ctx, updateQuery,
 		updated.ID, updated.SensorID,
 		updated.TemperatureMin, updated.TemperatureMax,
 		updated.HumidityMin, updated.HumidityMax,

--- a/backend/internal/repository/pg_environment.go
+++ b/backend/internal/repository/pg_environment.go
@@ -25,7 +25,8 @@ func (r *PgEnvironmentRepository) Store(reading *domain.EnvironmentReading) erro
 		INSERT INTO environment_readings (time, sensor_id, location, temperature, humidity, work_id, process_step_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
 	`
-	_, err := r.pool.Exec(ctx, query,
+	_, err := r.pool.Exec(
+		ctx, query,
 		reading.Time,
 		reading.SensorID,
 		reading.Location,

--- a/backend/internal/repository/pg_step.go
+++ b/backend/internal/repository/pg_step.go
@@ -38,7 +38,8 @@ func (r *PgStepRepository) Create(step *domain.ProcessStep) error {
 			 materials_used, notes, started_at, completed_at, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12)
 	`
-	_, err = r.pool.Exec(ctx, query,
+	_, err = r.pool.Exec(
+		ctx, query,
 		step.ID, step.WorkID, step.Name, step.Description, step.StepOrder, step.Category,
 		materialsJSON, step.Notes, step.StartedAt, step.CompletedAt, step.CreatedAt, step.UpdatedAt,
 	)
@@ -139,7 +140,8 @@ func (r *PgStepRepository) Update(step *domain.ProcessStep) error {
 		    materials_used = $7, notes = $8, started_at = $9, completed_at = $10, updated_at = $11
 		WHERE id = $1 AND work_id = $2
 	`
-	tag, err := r.pool.Exec(ctx, query,
+	tag, err := r.pool.Exec(
+		ctx, query,
 		step.ID, step.WorkID, step.Name, step.Description, step.StepOrder, step.Category,
 		materialsJSON, step.Notes, step.StartedAt, step.CompletedAt, step.UpdatedAt,
 	)

--- a/backend/internal/repository/pg_work.go
+++ b/backend/internal/repository/pg_work.go
@@ -90,7 +90,8 @@ func (r *PgWorkRepository) Create(work *domain.Work) error {
 		                   started_at, completed_at, created_at, updated_at)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
 	`
-	_, err := r.pool.Exec(ctx, query,
+	_, err := r.pool.Exec(
+		ctx, query,
 		work.ID, work.Title, work.Description, work.Technique, work.Material, work.Status,
 		work.StartedAt, work.CompletedAt, work.CreatedAt, work.UpdatedAt,
 	)
@@ -113,7 +114,8 @@ func (r *PgWorkRepository) Update(work *domain.Work) error {
 		    started_at = $7, completed_at = $8, updated_at = $9
 		WHERE id = $1
 	`
-	tag, err := r.pool.Exec(ctx, query,
+	tag, err := r.pool.Exec(
+		ctx, query,
 		work.ID, work.Title, work.Description, work.Technique, work.Material, work.Status,
 		work.StartedAt, work.CompletedAt, work.UpdatedAt,
 	)


### PR DESCRIPTION
## 概要
ローカル gofumpt v0.10.0 の pre-commit フックが repository 層4ファイルに整形を適用したため、独立PRとして分離。`pool.Exec(ctx, query, ...)` の引数折返し位置の標準化のみで、ロジック変更なし。

## 検証
- pre-commit で backend go test / golangci-lint / frontend vitest 全パス