### PR TITLE
refactor(backend): context伝播・graceful shutdown・カスケード重複解消・golangci整合 (#24 #22 #26 #25)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,7 @@
 version: "2"
 
 run:
-  go: "1.24"
+  go: "1.25"
 
 linters:
   enable:

--- a/backend/cmd/urushi-chronicle/main.go
+++ b/backend/cmd/urushi-chronicle/main.go
@@ -174,35 +174,43 @@ func main() {
 		IdleTimeout:  120 * time.Second,
 	}
 
-	// Channel to receive OS signals for graceful shutdown
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
+	// Cancel the context on SIGINT/SIGTERM (e.g. Cloud Run sends SIGTERM on
+	// shutdown) so in-flight requests are drained before the process exits.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
-	// Channel to receive server errors
-	errCh := make(chan error, 1)
+	const shutdownTimeout = 30 * time.Second
+	if err := runServer(ctx, srv, shutdownTimeout, logger); err != nil {
+		logger.Fatalf("%v", err)
+	}
+}
 
+// runServer starts srv in a background goroutine and blocks until ctx is
+// cancelled (e.g. via SIGINT/SIGTERM) or the server fails to serve. It then
+// performs a graceful shutdown bounded by shutdownTimeout, allowing in-flight
+// requests to complete before returning.
+func runServer(ctx context.Context, srv *http.Server, shutdownTimeout time.Duration, logger *log.Logger) error {
+	serveErr := make(chan error, 1)
 	go func() {
-		logger.Printf("API server starting on :%s", port)
+		logger.Printf("API server starting on %s", srv.Addr)
 		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			errCh <- err
+			serveErr <- err
 		}
 	}()
 
-	// Wait for shutdown signal or server error
 	select {
-	case sig := <-sigCh:
-		logger.Printf("received signal %v, initiating graceful shutdown...", sig)
-	case err := <-errCh:
-		logger.Printf("server error: %v, initiating shutdown...", err)
+	case <-ctx.Done():
+		logger.Println("shutdown signal received, draining in-flight requests...")
+	case err := <-serveErr:
+		return fmt.Errorf("server failed: %w", err)
 	}
 
-	// Graceful shutdown with 30-second timeout
-	const shutdownTimeout = 30 * time.Second
-	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), shutdownTimeout)
-	defer shutdownCancel()
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), shutdownTimeout)
+	defer cancel()
 
 	if err := srv.Shutdown(shutdownCtx); err != nil {
-		logger.Fatalf("graceful shutdown failed: %v", err)
+		return fmt.Errorf("graceful shutdown failed: %w", err)
 	}
 	logger.Println("server shut down gracefully")
+	return nil
 }

--- a/backend/cmd/urushi-chronicle/main_test.go
+++ b/backend/cmd/urushi-chronicle/main_test.go
@@ -1,7 +1,12 @@
 package main
 
 import (
+	"context"
+	"io"
+	"log"
+	"net/http"
 	"testing"
+	"time"
 )
 
 func TestPackageImports(t *testing.T) {
@@ -9,6 +14,47 @@ func TestPackageImports(t *testing.T) {
 	// The actual main() starts an HTTP server and blocks,
 	// so we only validate that the package builds successfully.
 	t.Log("main package compiles OK")
+}
+
+func TestRunServer_ShutsDownOnContextCancel(t *testing.T) {
+	srv := &http.Server{
+		Addr:    "127.0.0.1:0",
+		Handler: http.NewServeMux(),
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	logger := log.New(io.Discard, "", 0)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- runServer(ctx, srv, 5*time.Second, logger)
+	}()
+
+	// Give the server a moment to start listening, then request shutdown.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("expected clean graceful shutdown, got: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("runServer did not return after context cancellation")
+	}
+}
+
+func TestRunServer_ReturnsServeError(t *testing.T) {
+	// Port 99999 is out of the valid range, so ListenAndServe fails immediately.
+	srv := &http.Server{
+		Addr:    "127.0.0.1:99999",
+		Handler: http.NewServeMux(),
+	}
+	logger := log.New(io.Discard, "", 0)
+
+	err := runServer(context.Background(), srv, time.Second, logger)
+	if err == nil {
+		t.Fatal("expected an error when the server fails to listen")
+	}
 }
 
 func TestValidateStoreType(t *testing.T) {

--- a/backend/internal/handler/environment_handler.go
+++ b/backend/internal/handler/environment_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -106,7 +107,7 @@ func (h *EnvironmentHandler) handleThresholds(w http.ResponseWriter, r *http.Req
 	case http.MethodPost:
 		h.createThreshold(w, r)
 	case http.MethodGet:
-		h.listThresholds(w)
+		h.listThresholds(r.Context(), w)
 	default:
 		w.Header().Set("Allow", "GET, POST")
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -120,13 +121,15 @@ func (h *EnvironmentHandler) handleThresholdByID(w http.ResponseWriter, r *http.
 		return
 	}
 
+	ctx := r.Context()
+
 	switch r.Method {
 	case http.MethodGet:
-		h.getThreshold(w, id)
+		h.getThreshold(ctx, w, id)
 	case http.MethodPut:
-		h.updateThreshold(w, r, id)
+		h.updateThreshold(ctx, w, r, id)
 	case http.MethodDelete:
-		h.deleteThreshold(w, id)
+		h.deleteThreshold(ctx, w, id)
 	default:
 		w.Header().Set("Allow", "GET, PUT, DELETE")
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -178,7 +181,7 @@ func (h *EnvironmentHandler) ingestReading(w http.ResponseWriter, r *http.Reques
 		Humidity:    *req.Humidity,
 	}
 
-	if err := h.monitorSvc.ProcessReading(reading); err != nil {
+	if err := h.monitorSvc.ProcessReading(r.Context(), reading); err != nil {
 		writeValidationErrors(w, []string{err.Error()})
 		return
 	}
@@ -203,7 +206,7 @@ func (h *EnvironmentHandler) queryReadings(w http.ResponseWriter, r *http.Reques
 		limit = parsed
 	}
 
-	readings, err := h.envRepo.FindBySensorID(sensorID, limit)
+	readings, err := h.envRepo.FindBySensorID(r.Context(), sensorID, limit)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to query readings")
 		return
@@ -247,7 +250,7 @@ func (h *EnvironmentHandler) createThreshold(w http.ResponseWriter, r *http.Requ
 		return
 	}
 
-	if err := h.thresholdRepo.Create(threshold); err != nil {
+	if err := h.thresholdRepo.Create(r.Context(), threshold); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create threshold")
 		return
 	}
@@ -255,8 +258,8 @@ func (h *EnvironmentHandler) createThreshold(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusCreated, threshold)
 }
 
-func (h *EnvironmentHandler) listThresholds(w http.ResponseWriter) {
-	thresholds, err := h.thresholdRepo.FindAllEnabled()
+func (h *EnvironmentHandler) listThresholds(ctx context.Context, w http.ResponseWriter) {
+	thresholds, err := h.thresholdRepo.FindAllEnabled(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list thresholds")
 		return
@@ -268,8 +271,8 @@ func (h *EnvironmentHandler) listThresholds(w http.ResponseWriter) {
 	})
 }
 
-func (h *EnvironmentHandler) getThreshold(w http.ResponseWriter, id uuid.UUID) {
-	threshold, err := h.thresholdRepo.FindByID(id)
+func (h *EnvironmentHandler) getThreshold(ctx context.Context, w http.ResponseWriter, id uuid.UUID) {
+	threshold, err := h.thresholdRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "threshold not found")
@@ -281,7 +284,7 @@ func (h *EnvironmentHandler) getThreshold(w http.ResponseWriter, id uuid.UUID) {
 	writeJSON(w, http.StatusOK, threshold)
 }
 
-func (h *EnvironmentHandler) updateThreshold(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+func (h *EnvironmentHandler) updateThreshold(ctx context.Context, w http.ResponseWriter, r *http.Request, id uuid.UUID) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	var req updateThresholdRequest
@@ -293,7 +296,7 @@ func (h *EnvironmentHandler) updateThreshold(w http.ResponseWriter, r *http.Requ
 	// Use FindAndUpdate to atomically read-modify-write under a single lock,
 	// preventing race conditions on concurrent updates.
 	// Pointer fields (nil = not provided, non-nil = explicit value including zero).
-	updated, err := h.thresholdRepo.FindAndUpdate(id, func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error) {
+	updated, err := h.thresholdRepo.FindAndUpdate(ctx, id, func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error) {
 		if req.SensorID != "" {
 			existing.SensorID = req.SensorID
 		}
@@ -333,8 +336,8 @@ func (h *EnvironmentHandler) updateThreshold(w http.ResponseWriter, r *http.Requ
 	writeJSON(w, http.StatusOK, updated)
 }
 
-func (h *EnvironmentHandler) deleteThreshold(w http.ResponseWriter, id uuid.UUID) {
-	if err := h.thresholdRepo.Delete(id); err != nil {
+func (h *EnvironmentHandler) deleteThreshold(ctx context.Context, w http.ResponseWriter, id uuid.UUID) {
+	if err := h.thresholdRepo.Delete(ctx, id); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "threshold not found")
 			return

--- a/backend/internal/handler/environment_handler_test.go
+++ b/backend/internal/handler/environment_handler_test.go
@@ -2,6 +2,7 @@ package handler_test
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"log"
 	"net/http"
@@ -108,7 +109,7 @@ func TestEnvironmentHandler_QueryReadings(t *testing.T) {
 		Temperature: 25.0,
 		Humidity:    75.0,
 	}
-	if err := envRepo.Store(reading); err != nil {
+	if err := envRepo.Store(context.Background(), reading); err != nil {
 		t.Fatalf("store failed: %v", err)
 	}
 

--- a/backend/internal/handler/step_handler.go
+++ b/backend/internal/handler/step_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -64,6 +65,8 @@ type uploadRequest struct {
 //   - DELETE /api/v1/works/{workID}/steps/{stepID}
 //   - POST   /api/v1/works/{workID}/steps/{stepID}/upload
 func (h *StepHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+
 	workID, stepID, trailing, ok := h.parsePath(r.URL.Path)
 	if !ok {
 		writeError(w, http.StatusBadRequest, "invalid URL path")
@@ -71,7 +74,7 @@ func (h *StepHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Verify work exists
-	if _, err := h.workRepo.FindByID(workID); err != nil {
+	if _, err := h.workRepo.FindByID(ctx, workID); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
 			return
@@ -86,9 +89,9 @@ func (h *StepHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// /api/v1/works/{workID}/steps
 		switch r.Method {
 		case http.MethodPost:
-			h.createStep(w, r, workID)
+			h.createStep(ctx, w, r, workID)
 		case http.MethodGet:
-			h.listSteps(w, workID)
+			h.listSteps(ctx, w, workID)
 		default:
 			w.Header().Set("Allow", "GET, POST")
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -100,16 +103,16 @@ func (h *StepHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 			return
 		}
-		h.requestUploadURL(w, r, workID, stepID)
+		h.requestUploadURL(ctx, w, r, workID, stepID)
 	case stepID != uuid.Nil && trailing == "":
 		// /api/v1/works/{workID}/steps/{stepID}
 		switch r.Method {
 		case http.MethodGet:
-			h.getStep(w, workID, stepID)
+			h.getStep(ctx, w, workID, stepID)
 		case http.MethodPut:
-			h.updateStep(w, r, workID, stepID)
+			h.updateStep(ctx, w, r, workID, stepID)
 		case http.MethodDelete:
-			h.deleteStep(w, workID, stepID)
+			h.deleteStep(ctx, w, workID, stepID)
 		default:
 			w.Header().Set("Allow", "GET, PUT, DELETE")
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -163,7 +166,7 @@ func (h *StepHandler) parsePath(path string) (workID, stepID uuid.UUID, trailing
 	return uuid.Nil, uuid.Nil, "", false
 }
 
-func (h *StepHandler) createStep(w http.ResponseWriter, r *http.Request, workID uuid.UUID) {
+func (h *StepHandler) createStep(ctx context.Context, w http.ResponseWriter, r *http.Request, workID uuid.UUID) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	var req createStepRequest
@@ -192,7 +195,7 @@ func (h *StepHandler) createStep(w http.ResponseWriter, r *http.Request, workID 
 		return
 	}
 
-	if err := h.stepRepo.Create(step); err != nil {
+	if err := h.stepRepo.Create(ctx, step); err != nil {
 		if errors.Is(err, repository.ErrConflict) {
 			writeError(w, http.StatusConflict, err.Error())
 			return
@@ -204,8 +207,8 @@ func (h *StepHandler) createStep(w http.ResponseWriter, r *http.Request, workID 
 	writeJSON(w, http.StatusCreated, step)
 }
 
-func (h *StepHandler) listSteps(w http.ResponseWriter, workID uuid.UUID) {
-	steps, err := h.stepRepo.FindByWorkID(workID)
+func (h *StepHandler) listSteps(ctx context.Context, w http.ResponseWriter, workID uuid.UUID) {
+	steps, err := h.stepRepo.FindByWorkID(ctx, workID)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list steps")
 		return
@@ -217,8 +220,8 @@ func (h *StepHandler) listSteps(w http.ResponseWriter, workID uuid.UUID) {
 	})
 }
 
-func (h *StepHandler) getStep(w http.ResponseWriter, workID, stepID uuid.UUID) {
-	step, err := h.stepRepo.FindByID(workID, stepID)
+func (h *StepHandler) getStep(ctx context.Context, w http.ResponseWriter, workID, stepID uuid.UUID) {
+	step, err := h.stepRepo.FindByID(ctx, workID, stepID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "step not found")
@@ -231,10 +234,10 @@ func (h *StepHandler) getStep(w http.ResponseWriter, workID, stepID uuid.UUID) {
 	writeJSON(w, http.StatusOK, step)
 }
 
-func (h *StepHandler) updateStep(w http.ResponseWriter, r *http.Request, workID, stepID uuid.UUID) {
+func (h *StepHandler) updateStep(ctx context.Context, w http.ResponseWriter, r *http.Request, workID, stepID uuid.UUID) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
-	existing, err := h.stepRepo.FindByID(workID, stepID)
+	existing, err := h.stepRepo.FindByID(ctx, workID, stepID)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "step not found")
@@ -280,7 +283,7 @@ func (h *StepHandler) updateStep(w http.ResponseWriter, r *http.Request, workID,
 		return
 	}
 
-	if err := h.stepRepo.Update(existing); err != nil {
+	if err := h.stepRepo.Update(ctx, existing); err != nil {
 		if errors.Is(err, repository.ErrConflict) {
 			writeError(w, http.StatusConflict, err.Error())
 			return
@@ -292,8 +295,8 @@ func (h *StepHandler) updateStep(w http.ResponseWriter, r *http.Request, workID,
 	writeJSON(w, http.StatusOK, existing)
 }
 
-func (h *StepHandler) deleteStep(w http.ResponseWriter, workID, stepID uuid.UUID) {
-	if err := h.stepRepo.Delete(workID, stepID); err != nil {
+func (h *StepHandler) deleteStep(ctx context.Context, w http.ResponseWriter, workID, stepID uuid.UUID) {
+	if err := h.stepRepo.Delete(ctx, workID, stepID); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "step not found")
 			return
@@ -305,11 +308,11 @@ func (h *StepHandler) deleteStep(w http.ResponseWriter, workID, stepID uuid.UUID
 	w.WriteHeader(http.StatusNoContent)
 }
 
-func (h *StepHandler) requestUploadURL(w http.ResponseWriter, r *http.Request, workID, stepID uuid.UUID) {
+func (h *StepHandler) requestUploadURL(ctx context.Context, w http.ResponseWriter, r *http.Request, workID, stepID uuid.UUID) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	// Verify step exists
-	if _, err := h.stepRepo.FindByID(workID, stepID); err != nil {
+	if _, err := h.stepRepo.FindByID(ctx, workID, stepID); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "step not found")
 			return

--- a/backend/internal/handler/work_handler.go
+++ b/backend/internal/handler/work_handler.go
@@ -1,6 +1,7 @@
 package handler
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"net/http"
@@ -19,13 +20,27 @@ type WorkHandler struct {
 }
 
 // NewWorkHandler creates a new WorkHandler with the given repositories.
-// stepRepo is used to cascade-delete related steps when a work is deleted.
+// stepRepo is used to cascade-delete related steps when a work is deleted
+// (only for backends that do not cascade at the database level).
 func NewWorkHandler(workRepo repository.WorkRepository, stepRepo ...repository.StepRepository) *WorkHandler {
 	h := &WorkHandler{workRepo: workRepo}
 	if len(stepRepo) > 0 {
 		h.stepRepo = stepRepo[0]
 	}
 	return h
+}
+
+// cascadingWorkDeleter is implemented by WorkRepository backends that delete
+// related process steps automatically (e.g., PostgreSQL ON DELETE CASCADE).
+type cascadingWorkDeleter interface {
+	CascadesStepDeletion() bool
+}
+
+// workRepoCascadesSteps reports whether the repository deletes related steps
+// on its own, so the handler can skip an explicit, redundant step deletion.
+func workRepoCascadesSteps(repo repository.WorkRepository) bool {
+	cd, ok := repo.(cascadingWorkDeleter)
+	return ok && cd.CascadesStepDeletion()
 }
 
 // createWorkRequest is the JSON body for POST /api/v1/works.
@@ -58,13 +73,15 @@ func (h *WorkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	path := strings.TrimPrefix(r.URL.Path, prefix)
 	path = strings.TrimPrefix(path, "/")
 
+	ctx := r.Context()
+
 	// Collection endpoints (no ID segment)
 	if path == "" {
 		switch r.Method {
 		case http.MethodGet:
-			h.listWorks(w)
+			h.listWorks(ctx, w)
 		case http.MethodPost:
-			h.createWork(w, r)
+			h.createWork(ctx, w, r)
 		default:
 			w.Header().Set("Allow", "GET, POST")
 			writeError(w, http.StatusMethodNotAllowed, "method not allowed")
@@ -87,19 +104,19 @@ func (h *WorkHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	// Single-resource endpoints
 	switch r.Method {
 	case http.MethodGet:
-		h.getWork(w, id)
+		h.getWork(ctx, w, id)
 	case http.MethodPut:
-		h.updateWork(w, r, id)
+		h.updateWork(ctx, w, r, id)
 	case http.MethodDelete:
-		h.deleteWork(w, id)
+		h.deleteWork(ctx, w, id)
 	default:
 		w.Header().Set("Allow", "GET, PUT, DELETE")
 		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
 	}
 }
 
-func (h *WorkHandler) listWorks(w http.ResponseWriter) {
-	works, err := h.workRepo.FindAll()
+func (h *WorkHandler) listWorks(ctx context.Context, w http.ResponseWriter) {
+	works, err := h.workRepo.FindAll(ctx)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to list works")
 		return
@@ -111,8 +128,8 @@ func (h *WorkHandler) listWorks(w http.ResponseWriter) {
 	})
 }
 
-func (h *WorkHandler) getWork(w http.ResponseWriter, id uuid.UUID) {
-	work, err := h.workRepo.FindByID(id)
+func (h *WorkHandler) getWork(ctx context.Context, w http.ResponseWriter, id uuid.UUID) {
+	work, err := h.workRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
@@ -125,7 +142,7 @@ func (h *WorkHandler) getWork(w http.ResponseWriter, id uuid.UUID) {
 	writeJSON(w, http.StatusOK, work)
 }
 
-func (h *WorkHandler) createWork(w http.ResponseWriter, r *http.Request) {
+func (h *WorkHandler) createWork(ctx context.Context, w http.ResponseWriter, r *http.Request) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
 	var req createWorkRequest
@@ -152,7 +169,7 @@ func (h *WorkHandler) createWork(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := h.workRepo.Create(work); err != nil {
+	if err := h.workRepo.Create(ctx, work); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to create work")
 		return
 	}
@@ -160,10 +177,10 @@ func (h *WorkHandler) createWork(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusCreated, work)
 }
 
-func (h *WorkHandler) updateWork(w http.ResponseWriter, r *http.Request, id uuid.UUID) {
+func (h *WorkHandler) updateWork(ctx context.Context, w http.ResponseWriter, r *http.Request, id uuid.UUID) {
 	r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
 
-	existing, err := h.workRepo.FindByID(id)
+	existing, err := h.workRepo.FindByID(ctx, id)
 	if err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
@@ -211,7 +228,7 @@ func (h *WorkHandler) updateWork(w http.ResponseWriter, r *http.Request, id uuid
 		return
 	}
 
-	if err := h.workRepo.Update(existing); err != nil {
+	if err := h.workRepo.Update(ctx, existing); err != nil {
 		writeError(w, http.StatusInternalServerError, "failed to update work")
 		return
 	}
@@ -219,9 +236,9 @@ func (h *WorkHandler) updateWork(w http.ResponseWriter, r *http.Request, id uuid
 	writeJSON(w, http.StatusOK, existing)
 }
 
-func (h *WorkHandler) deleteWork(w http.ResponseWriter, id uuid.UUID) {
+func (h *WorkHandler) deleteWork(ctx context.Context, w http.ResponseWriter, id uuid.UUID) {
 	// Verify work exists before attempting deletion.
-	if _, err := h.workRepo.FindByID(id); err != nil {
+	if _, err := h.workRepo.FindByID(ctx, id); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
 			return
@@ -230,19 +247,18 @@ func (h *WorkHandler) deleteWork(w http.ResponseWriter, id uuid.UUID) {
 		return
 	}
 
-	// Cascade: delete all associated process steps BEFORE the work itself.
-	// This prevents orphaned steps if the work deletion succeeds but step
-	// deletion would fail, and ensures correct ordering in in-memory mode
-	// (PostgreSQL handles this via ON DELETE CASCADE, but application-level
-	// ordering must also be correct for the in-memory store).
-	if h.stepRepo != nil {
-		if err := h.stepRepo.DeleteByWorkID(id); err != nil {
+	// Cascade: delete associated process steps before the work itself. This is
+	// skipped when the work repository cascades at the database level (PostgreSQL
+	// ON DELETE CASCADE), avoiding a redundant double delete. The in-memory store
+	// does not cascade, so its steps are removed here explicitly.
+	if h.stepRepo != nil && !workRepoCascadesSteps(h.workRepo) {
+		if err := h.stepRepo.DeleteByWorkID(ctx, id); err != nil {
 			writeError(w, http.StatusInternalServerError, "failed to delete associated steps")
 			return
 		}
 	}
 
-	if err := h.workRepo.Delete(id); err != nil {
+	if err := h.workRepo.Delete(ctx, id); err != nil {
 		if errors.Is(err, repository.ErrNotFound) {
 			writeError(w, http.StatusNotFound, "work not found")
 			return

--- a/backend/internal/handler/work_handler_test.go
+++ b/backend/internal/handler/work_handler_test.go
@@ -1,6 +1,7 @@
 package handler_test
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
@@ -346,7 +347,7 @@ func TestDeleteWork_CascadeDeletesSteps(t *testing.T) {
 
 	// Seed a process step for the work
 	stepID := uuid.New()
-	if err := stepRepo.Create(&domain.ProcessStep{
+	if err := stepRepo.Create(context.Background(), &domain.ProcessStep{
 		ID:        stepID,
 		WorkID:    workID,
 		Name:      "下塗り",
@@ -360,7 +361,7 @@ func TestDeleteWork_CascadeDeletesSteps(t *testing.T) {
 	}
 
 	// Verify step exists before delete
-	steps, err := stepRepo.FindByWorkID(workID)
+	steps, err := stepRepo.FindByWorkID(context.Background(), workID)
 	if err != nil {
 		t.Fatalf("failed to find steps: %v", err)
 	}
@@ -378,18 +379,75 @@ func TestDeleteWork_CascadeDeletesSteps(t *testing.T) {
 	}
 
 	// Verify work is deleted
-	_, err = workRepo.FindByID(workID)
+	_, err = workRepo.FindByID(context.Background(), workID)
 	if err == nil {
 		t.Error("expected work to be deleted, but FindByID returned no error")
 	}
 
 	// Verify steps are cascade-deleted
-	steps, err = stepRepo.FindByWorkID(workID)
+	steps, err = stepRepo.FindByWorkID(context.Background(), workID)
 	if err != nil {
 		t.Fatalf("failed to find steps after delete: %v", err)
 	}
 	if len(steps) != 0 {
 		t.Errorf("expected 0 steps after cascade delete, got %d", len(steps))
+	}
+}
+
+// fakeCascadingWorkRepo behaves like the PostgreSQL work repository: it reports
+// that related steps are deleted automatically via ON DELETE CASCADE.
+type fakeCascadingWorkRepo struct {
+	*repository.MemoryWorkRepository
+}
+
+func (f *fakeCascadingWorkRepo) CascadesStepDeletion() bool { return true }
+
+// spyStepRepo records whether DeleteByWorkID was invoked.
+type spyStepRepo struct {
+	*repository.MemoryStepRepository
+	deleteByWorkIDCalled bool
+}
+
+func (s *spyStepRepo) DeleteByWorkID(ctx context.Context, workID uuid.UUID) error {
+	s.deleteByWorkIDCalled = true
+	return s.MemoryStepRepository.DeleteByWorkID(ctx, workID)
+}
+
+// TestDeleteWork_PGCascade_SkipsExplicitStepDeletion verifies that when the work
+// repository cascades at the database level (PostgreSQL), the handler does NOT
+// also delete steps explicitly, avoiding a redundant double delete (#26).
+func TestDeleteWork_PGCascade_SkipsExplicitStepDeletion(t *testing.T) {
+	memWork := repository.NewMemoryWorkRepository()
+	workRepo := &fakeCascadingWorkRepo{MemoryWorkRepository: memWork}
+	stepRepo := &spyStepRepo{MemoryStepRepository: repository.NewMemoryStepRepository()}
+	h := handler.NewWorkHandler(workRepo, stepRepo)
+
+	workID := uuid.New()
+	now := time.Now().UTC()
+	memWork.Seed(&domain.Work{
+		ID:        workID,
+		Title:     "PGカスケード削除テスト",
+		Technique: domain.TechniqueMakie,
+		Status:    domain.WorkStatusInProgress,
+		StartedAt: now,
+		CreatedAt: now,
+		UpdatedAt: now,
+	})
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/works/"+workID.String(), nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", rr.Code, rr.Body.String())
+	}
+	if stepRepo.deleteByWorkIDCalled {
+		t.Error("expected explicit DeleteByWorkID to be skipped when the work repo cascades, but it was called")
+	}
+
+	// The work itself must still be gone.
+	if _, err := memWork.FindByID(context.Background(), workID); err == nil {
+		t.Error("expected work to be deleted")
 	}
 }
 

--- a/backend/internal/monitor/service.go
+++ b/backend/internal/monitor/service.go
@@ -3,6 +3,7 @@
 package monitor
 
 import (
+	"context"
 	"log"
 
 	"github.com/akaitigo/urushi-chronicle/internal/alert"
@@ -36,20 +37,20 @@ func NewService(
 // ProcessReading stores a reading and evaluates it against all applicable alert thresholds.
 // If any threshold is exceeded, an alert notification is sent.
 // Storage errors are returned immediately. Alert notification errors are logged but do not
-// prevent the reading from being stored.
-func (s *Service) ProcessReading(reading domain.EnvironmentReading) error {
+// prevent the reading from being stored. The context is propagated to all DB operations.
+func (s *Service) ProcessReading(ctx context.Context, reading domain.EnvironmentReading) error {
 	// Validate the reading
 	if err := reading.Validate(); err != nil {
 		return err
 	}
 
 	// Store the reading
-	if err := s.envRepo.Store(&reading); err != nil {
+	if err := s.envRepo.Store(ctx, &reading); err != nil {
 		return err
 	}
 
 	// Look up applicable thresholds for this sensor
-	thresholds, err := s.thresholdRepo.FindBySensorID(reading.SensorID)
+	thresholds, err := s.thresholdRepo.FindBySensorID(ctx, reading.SensorID)
 	if err != nil {
 		s.logger.Printf("warning: failed to lookup thresholds for sensor %s: %v", reading.SensorID, err)
 		return nil

--- a/backend/internal/monitor/service_test.go
+++ b/backend/internal/monitor/service_test.go
@@ -1,6 +1,7 @@
 package monitor_test
 
 import (
+	"context"
 	"log"
 	"os"
 	"testing"
@@ -47,11 +48,11 @@ func TestService_ProcessReading_StoresReading(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	stored, err := envRepo.FindBySensorID("esp32-001", 10)
+	stored, err := envRepo.FindBySensorID(context.Background(), "esp32-001", 10)
 	if err != nil {
 		t.Fatalf("find failed: %v", err)
 	}
@@ -88,7 +89,7 @@ func TestService_ProcessReading_TriggersAlert(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -124,7 +125,7 @@ func TestService_ProcessReading_NoAlertWhenWithinRange(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -158,7 +159,7 @@ func TestService_ProcessReading_NoAlertForDisabledThreshold(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -191,7 +192,7 @@ func TestService_ProcessReading_NoAlertForDifferentSensor(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
@@ -212,7 +213,7 @@ func TestService_ProcessReading_InvalidReading(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := svc.ProcessReading(reading); err == nil {
+	if err := svc.ProcessReading(context.Background(), reading); err == nil {
 		t.Error("expected error for invalid reading")
 	}
 }
@@ -242,7 +243,7 @@ func TestService_ProcessReading_HumidityAlert(t *testing.T) {
 		Humidity:    50.0, // below 70.0 minimum
 	}
 
-	if err := svc.ProcessReading(reading); err != nil {
+	if err := svc.ProcessReading(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 

--- a/backend/internal/repository/alert_threshold_repository.go
+++ b/backend/internal/repository/alert_threshold_repository.go
@@ -1,6 +1,8 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/akaitigo/urushi-chronicle/internal/domain"
 	"github.com/google/uuid"
 )
@@ -8,18 +10,18 @@ import (
 // AlertThresholdRepository defines the interface for alert threshold persistence.
 type AlertThresholdRepository interface {
 	// Create stores a new alert threshold.
-	Create(threshold *domain.AlertThreshold) error
+	Create(ctx context.Context, threshold *domain.AlertThreshold) error
 	// FindByID retrieves an alert threshold by its ID.
-	FindByID(id uuid.UUID) (*domain.AlertThreshold, error)
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.AlertThreshold, error)
 	// FindBySensorID retrieves all enabled alert thresholds for a given sensor.
-	FindBySensorID(sensorID string) ([]domain.AlertThreshold, error)
+	FindBySensorID(ctx context.Context, sensorID string) ([]domain.AlertThreshold, error)
 	// FindAllEnabled retrieves all enabled alert thresholds.
-	FindAllEnabled() ([]domain.AlertThreshold, error)
+	FindAllEnabled(ctx context.Context) ([]domain.AlertThreshold, error)
 	// Update replaces an existing alert threshold.
-	Update(threshold *domain.AlertThreshold) error
+	Update(ctx context.Context, threshold *domain.AlertThreshold) error
 	// FindAndUpdate atomically retrieves and updates a threshold under a single lock.
 	// The updateFn receives the current threshold and returns the updated version.
-	FindAndUpdate(id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error)
+	FindAndUpdate(ctx context.Context, id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error)
 	// Delete removes an alert threshold by its ID.
-	Delete(id uuid.UUID) error
+	Delete(ctx context.Context, id uuid.UUID) error
 }

--- a/backend/internal/repository/environment_repository.go
+++ b/backend/internal/repository/environment_repository.go
@@ -1,13 +1,15 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/akaitigo/urushi-chronicle/internal/domain"
 )
 
 // EnvironmentRepository defines the interface for environment reading persistence.
 type EnvironmentRepository interface {
 	// Store saves a single environment reading.
-	Store(reading *domain.EnvironmentReading) error
+	Store(ctx context.Context, reading *domain.EnvironmentReading) error
 	// FindBySensorID retrieves all readings for a given sensor, ordered by time descending.
-	FindBySensorID(sensorID string, limit int) ([]domain.EnvironmentReading, error)
+	FindBySensorID(ctx context.Context, sensorID string, limit int) ([]domain.EnvironmentReading, error)
 }

--- a/backend/internal/repository/memory_alert_threshold.go
+++ b/backend/internal/repository/memory_alert_threshold.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"sync"
 
 	"github.com/akaitigo/urushi-chronicle/internal/domain"
@@ -21,7 +22,7 @@ func NewMemoryAlertThresholdRepository() *MemoryAlertThresholdRepository {
 }
 
 // Create stores a new alert threshold.
-func (r *MemoryAlertThresholdRepository) Create(threshold *domain.AlertThreshold) error {
+func (r *MemoryAlertThresholdRepository) Create(_ context.Context, threshold *domain.AlertThreshold) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -31,7 +32,7 @@ func (r *MemoryAlertThresholdRepository) Create(threshold *domain.AlertThreshold
 }
 
 // FindByID retrieves an alert threshold by its ID.
-func (r *MemoryAlertThresholdRepository) FindByID(id uuid.UUID) (*domain.AlertThreshold, error) {
+func (r *MemoryAlertThresholdRepository) FindByID(_ context.Context, id uuid.UUID) (*domain.AlertThreshold, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -44,7 +45,7 @@ func (r *MemoryAlertThresholdRepository) FindByID(id uuid.UUID) (*domain.AlertTh
 }
 
 // FindBySensorID retrieves all enabled alert thresholds for a given sensor.
-func (r *MemoryAlertThresholdRepository) FindBySensorID(sensorID string) ([]domain.AlertThreshold, error) {
+func (r *MemoryAlertThresholdRepository) FindBySensorID(_ context.Context, sensorID string) ([]domain.AlertThreshold, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -58,7 +59,7 @@ func (r *MemoryAlertThresholdRepository) FindBySensorID(sensorID string) ([]doma
 }
 
 // FindAllEnabled retrieves all enabled alert thresholds.
-func (r *MemoryAlertThresholdRepository) FindAllEnabled() ([]domain.AlertThreshold, error) {
+func (r *MemoryAlertThresholdRepository) FindAllEnabled(_ context.Context) ([]domain.AlertThreshold, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -72,7 +73,7 @@ func (r *MemoryAlertThresholdRepository) FindAllEnabled() ([]domain.AlertThresho
 }
 
 // Update replaces an existing alert threshold.
-func (r *MemoryAlertThresholdRepository) Update(threshold *domain.AlertThreshold) error {
+func (r *MemoryAlertThresholdRepository) Update(_ context.Context, threshold *domain.AlertThreshold) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -85,7 +86,7 @@ func (r *MemoryAlertThresholdRepository) Update(threshold *domain.AlertThreshold
 }
 
 // FindAndUpdate atomically retrieves and updates a threshold under a single lock.
-func (r *MemoryAlertThresholdRepository) FindAndUpdate(id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error) {
+func (r *MemoryAlertThresholdRepository) FindAndUpdate(_ context.Context, id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -106,7 +107,7 @@ func (r *MemoryAlertThresholdRepository) FindAndUpdate(id uuid.UUID, updateFn fu
 }
 
 // Delete removes an alert threshold by its ID.
-func (r *MemoryAlertThresholdRepository) Delete(id uuid.UUID) error {
+func (r *MemoryAlertThresholdRepository) Delete(_ context.Context, id uuid.UUID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/backend/internal/repository/memory_alert_threshold_test.go
+++ b/backend/internal/repository/memory_alert_threshold_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"errors"
 	"testing"
 	"time"
@@ -28,11 +29,11 @@ func TestMemoryAlertThresholdRepository_CreateAndFindByID(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 	threshold := validAlertThreshold()
 
-	if err := repo.Create(threshold); err != nil {
+	if err := repo.Create(context.Background(), threshold); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	found, err := repo.FindByID(threshold.ID)
+	found, err := repo.FindByID(context.Background(), threshold.ID)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -44,7 +45,7 @@ func TestMemoryAlertThresholdRepository_CreateAndFindByID(t *testing.T) {
 func TestMemoryAlertThresholdRepository_FindByID_NotFound(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 
-	_, err := repo.FindByID(uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New())
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -66,12 +67,12 @@ func TestMemoryAlertThresholdRepository_FindBySensorID(t *testing.T) {
 	t3.Enabled = true
 
 	for _, th := range []*domain.AlertThreshold{t1, t2, t3} {
-		if err := repo.Create(th); err != nil {
+		if err := repo.Create(context.Background(), th); err != nil {
 			t.Fatalf("create failed: %v", err)
 		}
 	}
 
-	results, err := repo.FindBySensorID("esp32-001")
+	results, err := repo.FindBySensorID(context.Background(), "esp32-001")
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -89,12 +90,12 @@ func TestMemoryAlertThresholdRepository_FindAllEnabled(t *testing.T) {
 	disabled.Enabled = false
 
 	for _, th := range []*domain.AlertThreshold{enabled, disabled} {
-		if err := repo.Create(th); err != nil {
+		if err := repo.Create(context.Background(), th); err != nil {
 			t.Fatalf("create failed: %v", err)
 		}
 	}
 
-	results, err := repo.FindAllEnabled()
+	results, err := repo.FindAllEnabled(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -106,16 +107,16 @@ func TestMemoryAlertThresholdRepository_FindAllEnabled(t *testing.T) {
 func TestMemoryAlertThresholdRepository_Update(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 	threshold := validAlertThreshold()
-	if err := repo.Create(threshold); err != nil {
+	if err := repo.Create(context.Background(), threshold); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 
 	threshold.TemperatureMax = 35.0
-	if err := repo.Update(threshold); err != nil {
+	if err := repo.Update(context.Background(), threshold); err != nil {
 		t.Fatalf("update failed: %v", err)
 	}
 
-	found, err := repo.FindByID(threshold.ID)
+	found, err := repo.FindByID(context.Background(), threshold.ID)
 	if err != nil {
 		t.Fatalf("find failed: %v", err)
 	}
@@ -128,7 +129,7 @@ func TestMemoryAlertThresholdRepository_Update_NotFound(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 	threshold := validAlertThreshold()
 
-	err := repo.Update(threshold)
+	err := repo.Update(context.Background(), threshold)
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -137,15 +138,15 @@ func TestMemoryAlertThresholdRepository_Update_NotFound(t *testing.T) {
 func TestMemoryAlertThresholdRepository_Delete(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 	threshold := validAlertThreshold()
-	if err := repo.Create(threshold); err != nil {
+	if err := repo.Create(context.Background(), threshold); err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 
-	if err := repo.Delete(threshold.ID); err != nil {
+	if err := repo.Delete(context.Background(), threshold.ID); err != nil {
 		t.Fatalf("delete failed: %v", err)
 	}
 
-	_, err := repo.FindByID(threshold.ID)
+	_, err := repo.FindByID(context.Background(), threshold.ID)
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -154,7 +155,7 @@ func TestMemoryAlertThresholdRepository_Delete(t *testing.T) {
 func TestMemoryAlertThresholdRepository_Delete_NotFound(t *testing.T) {
 	repo := repository.NewMemoryAlertThresholdRepository()
 
-	err := repo.Delete(uuid.New())
+	err := repo.Delete(context.Background(), uuid.New())
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/backend/internal/repository/memory_environment.go
+++ b/backend/internal/repository/memory_environment.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"sort"
 	"sync"
 
@@ -33,7 +34,7 @@ func NewMemoryEnvironmentRepository() *MemoryEnvironmentRepository {
 
 // Store saves a single environment reading using a ring buffer.
 // When the buffer is full, the oldest entry is overwritten and its index entry is removed.
-func (r *MemoryEnvironmentRepository) Store(reading *domain.EnvironmentReading) error {
+func (r *MemoryEnvironmentRepository) Store(_ context.Context, reading *domain.EnvironmentReading) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -82,7 +83,7 @@ func (r *MemoryEnvironmentRepository) removeFromIndex(sensorID string, pos int) 
 // FindBySensorID retrieves readings for a given sensor, ordered by time descending.
 // If limit <= 0, all readings are returned.
 // Uses the sensor_id index for O(k) lookup instead of O(n) full scan.
-func (r *MemoryEnvironmentRepository) FindBySensorID(sensorID string, limit int) ([]domain.EnvironmentReading, error) {
+func (r *MemoryEnvironmentRepository) FindBySensorID(_ context.Context, sensorID string, limit int) ([]domain.EnvironmentReading, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 

--- a/backend/internal/repository/memory_environment_test.go
+++ b/backend/internal/repository/memory_environment_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -18,11 +19,11 @@ func TestMemoryEnvironmentRepository_Store(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := repo.Store(reading); err != nil {
+	if err := repo.Store(context.Background(), reading); err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
 
-	readings, err := repo.FindBySensorID("esp32-001", 10)
+	readings, err := repo.FindBySensorID(context.Background(), "esp32-001", 10)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -37,7 +38,7 @@ func TestMemoryEnvironmentRepository_Store(t *testing.T) {
 func TestMemoryEnvironmentRepository_FindBySensorID_NoResults(t *testing.T) {
 	repo := repository.NewMemoryEnvironmentRepository()
 
-	readings, err := repo.FindBySensorID("nonexistent", 10)
+	readings, err := repo.FindBySensorID(context.Background(), "nonexistent", 10)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -58,12 +59,12 @@ func TestMemoryEnvironmentRepository_FindBySensorID_Limit(t *testing.T) {
 			Temperature: 20.0 + float64(i),
 			Humidity:    70.0,
 		}
-		if err := repo.Store(reading); err != nil {
+		if err := repo.Store(context.Background(), reading); err != nil {
 			t.Fatalf("store failed: %v", err)
 		}
 	}
 
-	readings, err := repo.FindBySensorID("esp32-001", 3)
+	readings, err := repo.FindBySensorID(context.Background(), "esp32-001", 3)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}
@@ -87,12 +88,12 @@ func TestMemoryEnvironmentRepository_FindBySensorID_FiltersBySensor(t *testing.T
 			Temperature: 25.0,
 			Humidity:    75.0,
 		}
-		if err := repo.Store(reading); err != nil {
+		if err := repo.Store(context.Background(), reading); err != nil {
 			t.Fatalf("store failed: %v", err)
 		}
 	}
 
-	readings, err := repo.FindBySensorID("esp32-001", 10)
+	readings, err := repo.FindBySensorID(context.Background(), "esp32-001", 10)
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
 	}

--- a/backend/internal/repository/memory_step.go
+++ b/backend/internal/repository/memory_step.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"sort"
 	"sync"
 
@@ -22,7 +23,7 @@ func NewMemoryStepRepository() *MemoryStepRepository {
 }
 
 // Create stores a new process step. Returns ErrConflict if step_order is already taken for the work.
-func (r *MemoryStepRepository) Create(step *domain.ProcessStep) error {
+func (r *MemoryStepRepository) Create(_ context.Context, step *domain.ProcessStep) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -45,7 +46,7 @@ func (r *MemoryStepRepository) Create(step *domain.ProcessStep) error {
 }
 
 // FindByID retrieves a single process step by work ID and step ID.
-func (r *MemoryStepRepository) FindByID(workID, stepID uuid.UUID) (*domain.ProcessStep, error) {
+func (r *MemoryStepRepository) FindByID(_ context.Context, workID, stepID uuid.UUID) (*domain.ProcessStep, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -62,7 +63,7 @@ func (r *MemoryStepRepository) FindByID(workID, stepID uuid.UUID) (*domain.Proce
 }
 
 // FindByWorkID retrieves all process steps for a work, ordered by step_order.
-func (r *MemoryStepRepository) FindByWorkID(workID uuid.UUID) ([]domain.ProcessStep, error) {
+func (r *MemoryStepRepository) FindByWorkID(_ context.Context, workID uuid.UUID) ([]domain.ProcessStep, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -82,7 +83,7 @@ func (r *MemoryStepRepository) FindByWorkID(workID uuid.UUID) ([]domain.ProcessS
 }
 
 // Update replaces an existing process step. Returns ErrNotFound if it does not exist.
-func (r *MemoryStepRepository) Update(step *domain.ProcessStep) error {
+func (r *MemoryStepRepository) Update(_ context.Context, step *domain.ProcessStep) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -107,7 +108,7 @@ func (r *MemoryStepRepository) Update(step *domain.ProcessStep) error {
 }
 
 // Delete removes a process step. Returns ErrNotFound if it does not exist.
-func (r *MemoryStepRepository) Delete(workID, stepID uuid.UUID) error {
+func (r *MemoryStepRepository) Delete(_ context.Context, workID, stepID uuid.UUID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -124,7 +125,7 @@ func (r *MemoryStepRepository) Delete(workID, stepID uuid.UUID) error {
 
 // DeleteByWorkID removes all process steps associated with a given work.
 // Returns nil if the work has no steps (idempotent).
-func (r *MemoryStepRepository) DeleteByWorkID(workID uuid.UUID) error {
+func (r *MemoryStepRepository) DeleteByWorkID(_ context.Context, workID uuid.UUID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/backend/internal/repository/memory_step_test.go
+++ b/backend/internal/repository/memory_step_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,11 +28,11 @@ func TestMemoryStepRepository_CreateAndFindByID(t *testing.T) {
 	workID := uuid.New()
 	step := newStep(workID, 1)
 
-	if err := repo.Create(step); err != nil {
+	if err := repo.Create(context.Background(), step); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	found, err := repo.FindByID(workID, step.ID)
+	found, err := repo.FindByID(context.Background(), workID, step.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -42,7 +43,7 @@ func TestMemoryStepRepository_CreateAndFindByID(t *testing.T) {
 
 func TestMemoryStepRepository_FindByID_NotFound(t *testing.T) {
 	repo := repository.NewMemoryStepRepository()
-	_, err := repo.FindByID(uuid.New(), uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New(), uuid.New())
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -55,12 +56,12 @@ func TestMemoryStepRepository_FindByWorkID_Ordered(t *testing.T) {
 	// Create in reverse order
 	for _, order := range []int{3, 1, 2} {
 		step := newStep(workID, order)
-		if err := repo.Create(step); err != nil {
+		if err := repo.Create(context.Background(), step); err != nil {
 			t.Fatalf("Create failed: %v", err)
 		}
 	}
 
-	steps, err := repo.FindByWorkID(workID)
+	steps, err := repo.FindByWorkID(context.Background(), workID)
 	if err != nil {
 		t.Fatalf("FindByWorkID failed: %v", err)
 	}
@@ -76,7 +77,7 @@ func TestMemoryStepRepository_FindByWorkID_Ordered(t *testing.T) {
 
 func TestMemoryStepRepository_FindByWorkID_EmptyResult(t *testing.T) {
 	repo := repository.NewMemoryStepRepository()
-	steps, err := repo.FindByWorkID(uuid.New())
+	steps, err := repo.FindByWorkID(context.Background(), uuid.New())
 	if err != nil {
 		t.Fatalf("FindByWorkID failed: %v", err)
 	}
@@ -90,12 +91,12 @@ func TestMemoryStepRepository_Create_StepOrderConflict(t *testing.T) {
 	workID := uuid.New()
 
 	step1 := newStep(workID, 1)
-	if err := repo.Create(step1); err != nil {
+	if err := repo.Create(context.Background(), step1); err != nil {
 		t.Fatalf("Create step1 failed: %v", err)
 	}
 
 	step2 := newStep(workID, 1) // same order
-	if err := repo.Create(step2); err != repository.ErrConflict {
+	if err := repo.Create(context.Background(), step2); err != repository.ErrConflict {
 		t.Errorf("expected ErrConflict, got %v", err)
 	}
 }
@@ -105,16 +106,16 @@ func TestMemoryStepRepository_Update(t *testing.T) {
 	workID := uuid.New()
 	step := newStep(workID, 1)
 
-	if err := repo.Create(step); err != nil {
+	if err := repo.Create(context.Background(), step); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
 	step.Name = "更新された工程"
-	if err := repo.Update(step); err != nil {
+	if err := repo.Update(context.Background(), step); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	found, err := repo.FindByID(workID, step.ID)
+	found, err := repo.FindByID(context.Background(), workID, step.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -126,7 +127,7 @@ func TestMemoryStepRepository_Update(t *testing.T) {
 func TestMemoryStepRepository_Update_NotFound(t *testing.T) {
 	repo := repository.NewMemoryStepRepository()
 	step := newStep(uuid.New(), 1)
-	if err := repo.Update(step); err != repository.ErrNotFound {
+	if err := repo.Update(context.Background(), step); err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }
@@ -137,12 +138,12 @@ func TestMemoryStepRepository_Update_StepOrderConflict(t *testing.T) {
 
 	step1 := newStep(workID, 1)
 	step2 := newStep(workID, 2)
-	_ = repo.Create(step1)
-	_ = repo.Create(step2)
+	_ = repo.Create(context.Background(), step1)
+	_ = repo.Create(context.Background(), step2)
 
 	// Try to change step2's order to 1
 	step2.StepOrder = 1
-	if err := repo.Update(step2); err != repository.ErrConflict {
+	if err := repo.Update(context.Background(), step2); err != repository.ErrConflict {
 		t.Errorf("expected ErrConflict, got %v", err)
 	}
 }
@@ -152,13 +153,13 @@ func TestMemoryStepRepository_Delete(t *testing.T) {
 	workID := uuid.New()
 	step := newStep(workID, 1)
 
-	_ = repo.Create(step)
+	_ = repo.Create(context.Background(), step)
 
-	if err := repo.Delete(workID, step.ID); err != nil {
+	if err := repo.Delete(context.Background(), workID, step.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
 
-	_, err := repo.FindByID(workID, step.ID)
+	_, err := repo.FindByID(context.Background(), workID, step.ID)
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -166,7 +167,7 @@ func TestMemoryStepRepository_Delete(t *testing.T) {
 
 func TestMemoryStepRepository_Delete_NotFound(t *testing.T) {
 	repo := repository.NewMemoryStepRepository()
-	if err := repo.Delete(uuid.New(), uuid.New()); err != repository.ErrNotFound {
+	if err := repo.Delete(context.Background(), uuid.New(), uuid.New()); err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
 }

--- a/backend/internal/repository/memory_work.go
+++ b/backend/internal/repository/memory_work.go
@@ -1,6 +1,7 @@
 package repository
 
 import (
+	"context"
 	"sync"
 
 	"github.com/akaitigo/urushi-chronicle/internal/domain"
@@ -21,7 +22,7 @@ func NewMemoryWorkRepository() *MemoryWorkRepository {
 }
 
 // FindByID retrieves a work by its ID. Returns ErrNotFound if it does not exist.
-func (r *MemoryWorkRepository) FindByID(id uuid.UUID) (*domain.Work, error) {
+func (r *MemoryWorkRepository) FindByID(_ context.Context, id uuid.UUID) (*domain.Work, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -34,7 +35,7 @@ func (r *MemoryWorkRepository) FindByID(id uuid.UUID) (*domain.Work, error) {
 }
 
 // FindAll retrieves all works from the repository.
-func (r *MemoryWorkRepository) FindAll() ([]domain.Work, error) {
+func (r *MemoryWorkRepository) FindAll(_ context.Context) ([]domain.Work, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -46,7 +47,7 @@ func (r *MemoryWorkRepository) FindAll() ([]domain.Work, error) {
 }
 
 // Create stores a new work. Returns ErrConflict if the ID already exists.
-func (r *MemoryWorkRepository) Create(work *domain.Work) error {
+func (r *MemoryWorkRepository) Create(_ context.Context, work *domain.Work) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -59,7 +60,7 @@ func (r *MemoryWorkRepository) Create(work *domain.Work) error {
 }
 
 // Update replaces an existing work. Returns ErrNotFound if not present.
-func (r *MemoryWorkRepository) Update(work *domain.Work) error {
+func (r *MemoryWorkRepository) Update(_ context.Context, work *domain.Work) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -72,7 +73,8 @@ func (r *MemoryWorkRepository) Update(work *domain.Work) error {
 }
 
 // Delete removes a work by ID. Returns ErrNotFound if not present.
-func (r *MemoryWorkRepository) Delete(id uuid.UUID) error {
+// The in-memory store does not cascade; callers delete related steps explicitly.
+func (r *MemoryWorkRepository) Delete(_ context.Context, id uuid.UUID) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 

--- a/backend/internal/repository/memory_work_test.go
+++ b/backend/internal/repository/memory_work_test.go
@@ -1,6 +1,7 @@
 package repository_test
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -27,7 +28,7 @@ func TestMemoryWorkRepository_FindByID(t *testing.T) {
 	work := newTestWork("テスト作品")
 	repo.Seed(work)
 
-	found, err := repo.FindByID(work.ID)
+	found, err := repo.FindByID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -38,7 +39,7 @@ func TestMemoryWorkRepository_FindByID(t *testing.T) {
 
 func TestMemoryWorkRepository_FindByID_NotFound(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
-	_, err := repo.FindByID(uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New())
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -46,7 +47,7 @@ func TestMemoryWorkRepository_FindByID_NotFound(t *testing.T) {
 
 func TestMemoryWorkRepository_FindAll_Empty(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
-	works, err := repo.FindAll()
+	works, err := repo.FindAll(context.Background())
 	if err != nil {
 		t.Fatalf("FindAll failed: %v", err)
 	}
@@ -61,7 +62,7 @@ func TestMemoryWorkRepository_FindAll_WithData(t *testing.T) {
 		repo.Seed(newTestWork("作品"))
 	}
 
-	works, err := repo.FindAll()
+	works, err := repo.FindAll(context.Background())
 	if err != nil {
 		t.Fatalf("FindAll failed: %v", err)
 	}
@@ -74,10 +75,10 @@ func TestMemoryWorkRepository_FindAll_ReturnsIndependentCopies(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 	repo.Seed(newTestWork("オリジナル"))
 
-	works, _ := repo.FindAll()
+	works, _ := repo.FindAll(context.Background())
 	works[0].Title = "変更後"
 
-	worksAgain, _ := repo.FindAll()
+	worksAgain, _ := repo.FindAll(context.Background())
 	if worksAgain[0].Title != "オリジナル" {
 		t.Errorf("FindAll should return copies, got %q", worksAgain[0].Title)
 	}
@@ -91,7 +92,7 @@ func TestMemoryWorkRepository_Seed_ReturnsIndependentCopy(t *testing.T) {
 	// Mutate original
 	work.Title = "変更後"
 
-	found, _ := repo.FindByID(work.ID)
+	found, _ := repo.FindByID(context.Background(), work.ID)
 	if found.Title != "オリジナル" {
 		t.Errorf("seed should store a copy, got %q", found.Title)
 	}
@@ -101,11 +102,11 @@ func TestMemoryWorkRepository_Create(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 	work := newTestWork("新規作品")
 
-	if err := repo.Create(work); err != nil {
+	if err := repo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	found, err := repo.FindByID(work.ID)
+	found, err := repo.FindByID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByID after Create failed: %v", err)
 	}
@@ -119,7 +120,7 @@ func TestMemoryWorkRepository_Create_Conflict(t *testing.T) {
 	work := newTestWork("作品")
 	repo.Seed(work)
 
-	err := repo.Create(work)
+	err := repo.Create(context.Background(), work)
 	if err != repository.ErrConflict {
 		t.Errorf("expected ErrConflict, got %v", err)
 	}
@@ -129,12 +130,12 @@ func TestMemoryWorkRepository_Create_StoresIndependentCopy(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 	work := newTestWork("オリジナル")
 
-	if err := repo.Create(work); err != nil {
+	if err := repo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 	work.Title = "変更後"
 
-	found, _ := repo.FindByID(work.ID)
+	found, _ := repo.FindByID(context.Background(), work.ID)
 	if found.Title != "オリジナル" {
 		t.Errorf("Create should store a copy, got %q", found.Title)
 	}
@@ -146,11 +147,11 @@ func TestMemoryWorkRepository_Update(t *testing.T) {
 	repo.Seed(work)
 
 	work.Title = "新タイトル"
-	if err := repo.Update(work); err != nil {
+	if err := repo.Update(context.Background(), work); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
-	found, _ := repo.FindByID(work.ID)
+	found, _ := repo.FindByID(context.Background(), work.ID)
 	if found.Title != "新タイトル" {
 		t.Errorf("expected '新タイトル', got %q", found.Title)
 	}
@@ -160,7 +161,7 @@ func TestMemoryWorkRepository_Update_NotFound(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 	work := newTestWork("存在しない")
 
-	err := repo.Update(work)
+	err := repo.Update(context.Background(), work)
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}
@@ -172,12 +173,12 @@ func TestMemoryWorkRepository_Update_StoresIndependentCopy(t *testing.T) {
 	repo.Seed(work)
 
 	work.Title = "更新後"
-	if err := repo.Update(work); err != nil {
+	if err := repo.Update(context.Background(), work); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 	work.Title = "さらに変更"
 
-	found, _ := repo.FindByID(work.ID)
+	found, _ := repo.FindByID(context.Background(), work.ID)
 	if found.Title != "更新後" {
 		t.Errorf("Update should store a copy, got %q", found.Title)
 	}
@@ -188,11 +189,11 @@ func TestMemoryWorkRepository_Delete(t *testing.T) {
 	work := newTestWork("削除対象")
 	repo.Seed(work)
 
-	if err := repo.Delete(work.ID); err != nil {
+	if err := repo.Delete(context.Background(), work.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
 
-	_, err := repo.FindByID(work.ID)
+	_, err := repo.FindByID(context.Background(), work.ID)
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -201,7 +202,7 @@ func TestMemoryWorkRepository_Delete(t *testing.T) {
 func TestMemoryWorkRepository_Delete_NotFound(t *testing.T) {
 	repo := repository.NewMemoryWorkRepository()
 
-	err := repo.Delete(uuid.New())
+	err := repo.Delete(context.Background(), uuid.New())
 	if err != repository.ErrNotFound {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/backend/internal/repository/pg_alert_threshold.go
+++ b/backend/internal/repository/pg_alert_threshold.go
@@ -22,8 +22,7 @@ func NewPgAlertThresholdRepository(pool *pgxpool.Pool) *PgAlertThresholdReposito
 }
 
 // Create stores a new alert threshold.
-func (r *PgAlertThresholdRepository) Create(threshold *domain.AlertThreshold) error {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) Create(ctx context.Context, threshold *domain.AlertThreshold) error {
 	query := `
 		INSERT INTO alert_thresholds
 			(id, sensor_id, temperature_min, temperature_max, humidity_min, humidity_max,
@@ -44,8 +43,7 @@ func (r *PgAlertThresholdRepository) Create(threshold *domain.AlertThreshold) er
 }
 
 // FindByID retrieves an alert threshold by its ID.
-func (r *PgAlertThresholdRepository) FindByID(id uuid.UUID) (*domain.AlertThreshold, error) {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.AlertThreshold, error) {
 	query := `
 		SELECT id, sensor_id, temperature_min, temperature_max, humidity_min, humidity_max,
 		       enabled, created_at, updated_at
@@ -69,8 +67,7 @@ func (r *PgAlertThresholdRepository) FindByID(id uuid.UUID) (*domain.AlertThresh
 }
 
 // FindBySensorID retrieves all enabled alert thresholds for a given sensor.
-func (r *PgAlertThresholdRepository) FindBySensorID(sensorID string) ([]domain.AlertThreshold, error) {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) FindBySensorID(ctx context.Context, sensorID string) ([]domain.AlertThreshold, error) {
 	query := `
 		SELECT id, sensor_id, temperature_min, temperature_max, humidity_min, humidity_max,
 		       enabled, created_at, updated_at
@@ -106,8 +103,7 @@ func (r *PgAlertThresholdRepository) FindBySensorID(sensorID string) ([]domain.A
 }
 
 // FindAllEnabled retrieves all enabled alert thresholds.
-func (r *PgAlertThresholdRepository) FindAllEnabled() ([]domain.AlertThreshold, error) {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) FindAllEnabled(ctx context.Context) ([]domain.AlertThreshold, error) {
 	query := `
 		SELECT id, sensor_id, temperature_min, temperature_max, humidity_min, humidity_max,
 		       enabled, created_at, updated_at
@@ -143,8 +139,7 @@ func (r *PgAlertThresholdRepository) FindAllEnabled() ([]domain.AlertThreshold, 
 }
 
 // Update replaces an existing alert threshold.
-func (r *PgAlertThresholdRepository) Update(threshold *domain.AlertThreshold) error {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) Update(ctx context.Context, threshold *domain.AlertThreshold) error {
 	query := `
 		UPDATE alert_thresholds
 		SET sensor_id = $2, temperature_min = $3, temperature_max = $4,
@@ -168,9 +163,7 @@ func (r *PgAlertThresholdRepository) Update(threshold *domain.AlertThreshold) er
 }
 
 // FindAndUpdate atomically retrieves and updates a threshold using a database transaction.
-func (r *PgAlertThresholdRepository) FindAndUpdate(id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error) {
-	ctx := context.Background()
-
+func (r *PgAlertThresholdRepository) FindAndUpdate(ctx context.Context, id uuid.UUID, updateFn func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error)) (*domain.AlertThreshold, error) {
 	tx, err := r.pool.Begin(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to begin transaction: %w", err)
@@ -231,8 +224,7 @@ func (r *PgAlertThresholdRepository) FindAndUpdate(id uuid.UUID, updateFn func(e
 }
 
 // Delete removes an alert threshold by its ID.
-func (r *PgAlertThresholdRepository) Delete(id uuid.UUID) error {
-	ctx := context.Background()
+func (r *PgAlertThresholdRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM alert_thresholds WHERE id = $1`
 	tag, err := r.pool.Exec(ctx, query, id)
 	if err != nil {

--- a/backend/internal/repository/pg_alert_threshold_test.go
+++ b/backend/internal/repository/pg_alert_threshold_test.go
@@ -53,16 +53,16 @@ func TestPgAlertThresholdRepository_CRUD(t *testing.T) {
 
 	threshold := newPgTestThreshold("test-alert-sensor")
 	t.Cleanup(func() {
-		_ = repo.Delete(threshold.ID)
+		_ = repo.Delete(context.Background(), threshold.ID)
 	})
 
 	// Create
-	if err := repo.Create(threshold); err != nil {
+	if err := repo.Create(context.Background(), threshold); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
 	// FindByID
-	found, err := repo.FindByID(threshold.ID)
+	found, err := repo.FindByID(context.Background(), threshold.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -71,7 +71,7 @@ func TestPgAlertThresholdRepository_CRUD(t *testing.T) {
 	}
 
 	// FindBySensorID
-	results, err := repo.FindBySensorID("test-alert-sensor")
+	results, err := repo.FindBySensorID(context.Background(), "test-alert-sensor")
 	if err != nil {
 		t.Fatalf("FindBySensorID failed: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestPgAlertThresholdRepository_CRUD(t *testing.T) {
 	}
 
 	// FindAllEnabled
-	all, err := repo.FindAllEnabled()
+	all, err := repo.FindAllEnabled(context.Background())
 	if err != nil {
 		t.Fatalf("FindAllEnabled failed: %v", err)
 	}
@@ -91,10 +91,10 @@ func TestPgAlertThresholdRepository_CRUD(t *testing.T) {
 	// Update
 	found.TemperatureMax = 35.0
 	found.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
-	if err := repo.Update(found); err != nil {
+	if err := repo.Update(context.Background(), found); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
-	updated, err := repo.FindByID(threshold.ID)
+	updated, err := repo.FindByID(context.Background(), threshold.ID)
 	if err != nil {
 		t.Fatalf("FindByID after update failed: %v", err)
 	}
@@ -103,10 +103,10 @@ func TestPgAlertThresholdRepository_CRUD(t *testing.T) {
 	}
 
 	// Delete
-	if err := repo.Delete(threshold.ID); err != nil {
+	if err := repo.Delete(context.Background(), threshold.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
-	_, err = repo.FindByID(threshold.ID)
+	_, err = repo.FindByID(context.Background(), threshold.ID)
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -117,14 +117,14 @@ func TestPgAlertThresholdRepository_FindAndUpdate(t *testing.T) {
 
 	threshold := newPgTestThreshold("test-fau-sensor")
 	t.Cleanup(func() {
-		_ = repo.Delete(threshold.ID)
+		_ = repo.Delete(context.Background(), threshold.ID)
 	})
 
-	if err := repo.Create(threshold); err != nil {
+	if err := repo.Create(context.Background(), threshold); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
-	updated, err := repo.FindAndUpdate(threshold.ID, func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error) {
+	updated, err := repo.FindAndUpdate(context.Background(), threshold.ID, func(existing *domain.AlertThreshold) (*domain.AlertThreshold, error) {
 		existing.HumidityMax = 90.0
 		existing.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
 		return existing, nil
@@ -140,7 +140,7 @@ func TestPgAlertThresholdRepository_FindAndUpdate(t *testing.T) {
 func TestPgAlertThresholdRepository_FindByID_NotFound(t *testing.T) {
 	repo := setupPgAlertThresholdRepo(t)
 
-	_, err := repo.FindByID(uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New())
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/backend/internal/repository/pg_environment.go
+++ b/backend/internal/repository/pg_environment.go
@@ -19,8 +19,7 @@ func NewPgEnvironmentRepository(pool *pgxpool.Pool) *PgEnvironmentRepository {
 }
 
 // Store inserts a single environment reading into the TimescaleDB hypertable.
-func (r *PgEnvironmentRepository) Store(reading *domain.EnvironmentReading) error {
-	ctx := context.Background()
+func (r *PgEnvironmentRepository) Store(ctx context.Context, reading *domain.EnvironmentReading) error {
 	query := `
 		INSERT INTO environment_readings (time, sensor_id, location, temperature, humidity, work_id, process_step_id)
 		VALUES ($1, $2, $3, $4, $5, $6, $7)
@@ -43,8 +42,7 @@ func (r *PgEnvironmentRepository) Store(reading *domain.EnvironmentReading) erro
 
 // FindBySensorID retrieves readings for a given sensor, ordered by time descending.
 // If limit <= 0, a default limit of 1000 is applied to prevent unbounded queries.
-func (r *PgEnvironmentRepository) FindBySensorID(sensorID string, limit int) ([]domain.EnvironmentReading, error) {
-	ctx := context.Background()
+func (r *PgEnvironmentRepository) FindBySensorID(ctx context.Context, sensorID string, limit int) ([]domain.EnvironmentReading, error) {
 	if limit <= 0 {
 		limit = 1000
 	}

--- a/backend/internal/repository/pg_environment_test.go
+++ b/backend/internal/repository/pg_environment_test.go
@@ -49,11 +49,11 @@ func TestPgEnvironmentRepository_StoreAndFind(t *testing.T) {
 		Humidity:    75.0,
 	}
 
-	if err := repo.Store(reading); err != nil {
+	if err := repo.Store(context.Background(), reading); err != nil {
 		t.Fatalf("Store failed: %v", err)
 	}
 
-	results, err := repo.FindBySensorID("test-sensor-001", 10)
+	results, err := repo.FindBySensorID(context.Background(), "test-sensor-001", 10)
 	if err != nil {
 		t.Fatalf("FindBySensorID failed: %v", err)
 	}
@@ -73,7 +73,7 @@ func TestPgEnvironmentRepository_StoreAndFind(t *testing.T) {
 func TestPgEnvironmentRepository_FindBySensorID_Empty(t *testing.T) {
 	repo := setupPgEnvRepo(t)
 
-	results, err := repo.FindBySensorID("test-nonexistent-sensor", 10)
+	results, err := repo.FindBySensorID(context.Background(), "test-nonexistent-sensor", 10)
 	if err != nil {
 		t.Fatalf("FindBySensorID failed: %v", err)
 	}

--- a/backend/internal/repository/pg_step.go
+++ b/backend/internal/repository/pg_step.go
@@ -24,9 +24,7 @@ func NewPgStepRepository(pool *pgxpool.Pool) *PgStepRepository {
 }
 
 // Create inserts a new process step. Returns ErrConflict if step_order is already taken for the work.
-func (r *PgStepRepository) Create(step *domain.ProcessStep) error {
-	ctx := context.Background()
-
+func (r *PgStepRepository) Create(ctx context.Context, step *domain.ProcessStep) error {
 	materialsJSON, err := json.Marshal(step.MaterialsUsed)
 	if err != nil {
 		return fmt.Errorf("failed to marshal materials_used: %w", err)
@@ -54,8 +52,7 @@ func (r *PgStepRepository) Create(step *domain.ProcessStep) error {
 }
 
 // FindByID retrieves a single process step by work ID and step ID.
-func (r *PgStepRepository) FindByID(workID, stepID uuid.UUID) (*domain.ProcessStep, error) {
-	ctx := context.Background()
+func (r *PgStepRepository) FindByID(ctx context.Context, workID, stepID uuid.UUID) (*domain.ProcessStep, error) {
 	query := `
 		SELECT id, work_id, name, description, step_order, category,
 		       materials_used, notes, started_at, completed_at, created_at, updated_at
@@ -83,8 +80,7 @@ func (r *PgStepRepository) FindByID(workID, stepID uuid.UUID) (*domain.ProcessSt
 }
 
 // FindByWorkID retrieves all process steps for a work, ordered by step_order.
-func (r *PgStepRepository) FindByWorkID(workID uuid.UUID) ([]domain.ProcessStep, error) {
-	ctx := context.Background()
+func (r *PgStepRepository) FindByWorkID(ctx context.Context, workID uuid.UUID) ([]domain.ProcessStep, error) {
 	query := `
 		SELECT id, work_id, name, description, step_order, category,
 		       materials_used, notes, started_at, completed_at, created_at, updated_at
@@ -126,9 +122,7 @@ func (r *PgStepRepository) FindByWorkID(workID uuid.UUID) ([]domain.ProcessStep,
 
 // Update replaces an existing process step. Returns ErrNotFound if it does not exist.
 // Returns ErrConflict if step_order uniqueness is violated.
-func (r *PgStepRepository) Update(step *domain.ProcessStep) error {
-	ctx := context.Background()
-
+func (r *PgStepRepository) Update(ctx context.Context, step *domain.ProcessStep) error {
 	materialsJSON, err := json.Marshal(step.MaterialsUsed)
 	if err != nil {
 		return fmt.Errorf("failed to marshal materials_used: %w", err)
@@ -159,8 +153,7 @@ func (r *PgStepRepository) Update(step *domain.ProcessStep) error {
 }
 
 // Delete removes a process step. Returns ErrNotFound if it does not exist.
-func (r *PgStepRepository) Delete(workID, stepID uuid.UUID) error {
-	ctx := context.Background()
+func (r *PgStepRepository) Delete(ctx context.Context, workID, stepID uuid.UUID) error {
 	query := `DELETE FROM process_steps WHERE work_id = $1 AND id = $2`
 	tag, err := r.pool.Exec(ctx, query, workID, stepID)
 	if err != nil {
@@ -174,8 +167,7 @@ func (r *PgStepRepository) Delete(workID, stepID uuid.UUID) error {
 
 // DeleteByWorkID removes all process steps associated with a given work.
 // Returns nil if the work has no steps (idempotent).
-func (r *PgStepRepository) DeleteByWorkID(workID uuid.UUID) error {
-	ctx := context.Background()
+func (r *PgStepRepository) DeleteByWorkID(ctx context.Context, workID uuid.UUID) error {
 	query := `DELETE FROM process_steps WHERE work_id = $1`
 	_, err := r.pool.Exec(ctx, query, workID)
 	if err != nil {

--- a/backend/internal/repository/pg_step_test.go
+++ b/backend/internal/repository/pg_step_test.go
@@ -56,22 +56,22 @@ func TestPgStepRepository_CRUD(t *testing.T) {
 	// Create parent work first
 	work := newPgTestWork("工程テスト親作品")
 	t.Cleanup(func() {
-		_ = stepRepo.DeleteByWorkID(work.ID)
-		_ = workRepo.Delete(work.ID)
+		_ = stepRepo.DeleteByWorkID(context.Background(), work.ID)
+		_ = workRepo.Delete(context.Background(), work.ID)
 	})
-	if err := workRepo.Create(work); err != nil {
+	if err := workRepo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create work failed: %v", err)
 	}
 
 	step := newPgTestStep(work.ID, "下塗り", 1)
 
 	// Create
-	if err := stepRepo.Create(step); err != nil {
+	if err := stepRepo.Create(context.Background(), step); err != nil {
 		t.Fatalf("Create step failed: %v", err)
 	}
 
 	// FindByID
-	found, err := stepRepo.FindByID(work.ID, step.ID)
+	found, err := stepRepo.FindByID(context.Background(), work.ID, step.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -83,7 +83,7 @@ func TestPgStepRepository_CRUD(t *testing.T) {
 	}
 
 	// FindByWorkID
-	steps, err := stepRepo.FindByWorkID(work.ID)
+	steps, err := stepRepo.FindByWorkID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByWorkID failed: %v", err)
 	}
@@ -94,15 +94,15 @@ func TestPgStepRepository_CRUD(t *testing.T) {
 	// Update
 	found.Name = "更新下塗り"
 	found.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
-	if err := stepRepo.Update(found); err != nil {
+	if err := stepRepo.Update(context.Background(), found); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
 
 	// Delete
-	if err := stepRepo.Delete(work.ID, step.ID); err != nil {
+	if err := stepRepo.Delete(context.Background(), work.ID, step.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
-	_, err = stepRepo.FindByID(work.ID, step.ID)
+	_, err = stepRepo.FindByID(context.Background(), work.ID, step.ID)
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -113,20 +113,20 @@ func TestPgStepRepository_Create_Conflict(t *testing.T) {
 
 	work := newPgTestWork("重複工程テスト")
 	t.Cleanup(func() {
-		_ = stepRepo.DeleteByWorkID(work.ID)
-		_ = workRepo.Delete(work.ID)
+		_ = stepRepo.DeleteByWorkID(context.Background(), work.ID)
+		_ = workRepo.Delete(context.Background(), work.ID)
 	})
-	if err := workRepo.Create(work); err != nil {
+	if err := workRepo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create work failed: %v", err)
 	}
 
 	step1 := newPgTestStep(work.ID, "工程1", 1)
-	if err := stepRepo.Create(step1); err != nil {
+	if err := stepRepo.Create(context.Background(), step1); err != nil {
 		t.Fatalf("Create step1 failed: %v", err)
 	}
 
 	step2 := newPgTestStep(work.ID, "工程2", 1) // same step_order
-	err := stepRepo.Create(step2)
+	err := stepRepo.Create(context.Background(), step2)
 	if !errors.Is(err, repository.ErrConflict) {
 		t.Errorf("expected ErrConflict on duplicate step_order, got %v", err)
 	}
@@ -137,24 +137,24 @@ func TestPgStepRepository_DeleteByWorkID(t *testing.T) {
 
 	work := newPgTestWork("一括削除テスト")
 	t.Cleanup(func() {
-		_ = workRepo.Delete(work.ID)
+		_ = workRepo.Delete(context.Background(), work.ID)
 	})
-	if err := workRepo.Create(work); err != nil {
+	if err := workRepo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create work failed: %v", err)
 	}
 
 	for i := 1; i <= 3; i++ {
 		step := newPgTestStep(work.ID, "工程", i)
-		if err := stepRepo.Create(step); err != nil {
+		if err := stepRepo.Create(context.Background(), step); err != nil {
 			t.Fatalf("Create step %d failed: %v", i, err)
 		}
 	}
 
-	if err := stepRepo.DeleteByWorkID(work.ID); err != nil {
+	if err := stepRepo.DeleteByWorkID(context.Background(), work.ID); err != nil {
 		t.Fatalf("DeleteByWorkID failed: %v", err)
 	}
 
-	steps, err := stepRepo.FindByWorkID(work.ID)
+	steps, err := stepRepo.FindByWorkID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByWorkID after delete failed: %v", err)
 	}

--- a/backend/internal/repository/pg_work.go
+++ b/backend/internal/repository/pg_work.go
@@ -22,9 +22,15 @@ func NewPgWorkRepository(pool *pgxpool.Pool) *PgWorkRepository {
 	return &PgWorkRepository{pool: pool}
 }
 
+// CascadesStepDeletion reports that this backend deletes related process steps
+// automatically via the ON DELETE CASCADE foreign key on process_steps.work_id.
+// Callers can use this to skip redundant application-level step deletion.
+func (r *PgWorkRepository) CascadesStepDeletion() bool {
+	return true
+}
+
 // FindByID retrieves a work by its ID.
-func (r *PgWorkRepository) FindByID(id uuid.UUID) (*domain.Work, error) {
-	ctx := context.Background()
+func (r *PgWorkRepository) FindByID(ctx context.Context, id uuid.UUID) (*domain.Work, error) {
 	query := `
 		SELECT id, title, description, technique, material, status,
 		       started_at, completed_at, created_at, updated_at
@@ -46,8 +52,7 @@ func (r *PgWorkRepository) FindByID(id uuid.UUID) (*domain.Work, error) {
 }
 
 // FindAll retrieves all works ordered by creation time descending.
-func (r *PgWorkRepository) FindAll() ([]domain.Work, error) {
-	ctx := context.Background()
+func (r *PgWorkRepository) FindAll(ctx context.Context) ([]domain.Work, error) {
 	query := `
 		SELECT id, title, description, technique, material, status,
 		       started_at, completed_at, created_at, updated_at
@@ -83,8 +88,7 @@ func (r *PgWorkRepository) FindAll() ([]domain.Work, error) {
 }
 
 // Create inserts a new work. Returns ErrConflict if the ID already exists.
-func (r *PgWorkRepository) Create(work *domain.Work) error {
-	ctx := context.Background()
+func (r *PgWorkRepository) Create(ctx context.Context, work *domain.Work) error {
 	query := `
 		INSERT INTO works (id, title, description, technique, material, status,
 		                   started_at, completed_at, created_at, updated_at)
@@ -106,8 +110,7 @@ func (r *PgWorkRepository) Create(work *domain.Work) error {
 }
 
 // Update replaces an existing work. Returns ErrNotFound if not present.
-func (r *PgWorkRepository) Update(work *domain.Work) error {
-	ctx := context.Background()
+func (r *PgWorkRepository) Update(ctx context.Context, work *domain.Work) error {
 	query := `
 		UPDATE works
 		SET title = $2, description = $3, technique = $4, material = $5, status = $6,
@@ -129,8 +132,8 @@ func (r *PgWorkRepository) Update(work *domain.Work) error {
 }
 
 // Delete removes a work by ID. Returns ErrNotFound if not present.
-func (r *PgWorkRepository) Delete(id uuid.UUID) error {
-	ctx := context.Background()
+// Related process_steps are removed automatically via ON DELETE CASCADE.
+func (r *PgWorkRepository) Delete(ctx context.Context, id uuid.UUID) error {
 	query := `DELETE FROM works WHERE id = $1`
 	tag, err := r.pool.Exec(ctx, query, id)
 	if err != nil {

--- a/backend/internal/repository/pg_work_test.go
+++ b/backend/internal/repository/pg_work_test.go
@@ -54,16 +54,16 @@ func TestPgWorkRepository_CRUD(t *testing.T) {
 	work := newPgTestWork("PGテスト蒔絵")
 	t.Cleanup(func() {
 		// Best-effort cleanup
-		_ = repo.Delete(work.ID)
+		_ = repo.Delete(context.Background(), work.ID)
 	})
 
 	// Create
-	if err := repo.Create(work); err != nil {
+	if err := repo.Create(context.Background(), work); err != nil {
 		t.Fatalf("Create failed: %v", err)
 	}
 
 	// FindByID
-	found, err := repo.FindByID(work.ID)
+	found, err := repo.FindByID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByID failed: %v", err)
 	}
@@ -74,10 +74,10 @@ func TestPgWorkRepository_CRUD(t *testing.T) {
 	// Update
 	found.Title = "更新後タイトル"
 	found.UpdatedAt = time.Now().UTC().Truncate(time.Microsecond)
-	if err := repo.Update(found); err != nil {
+	if err := repo.Update(context.Background(), found); err != nil {
 		t.Fatalf("Update failed: %v", err)
 	}
-	updated, err := repo.FindByID(work.ID)
+	updated, err := repo.FindByID(context.Background(), work.ID)
 	if err != nil {
 		t.Fatalf("FindByID after update failed: %v", err)
 	}
@@ -86,7 +86,7 @@ func TestPgWorkRepository_CRUD(t *testing.T) {
 	}
 
 	// FindAll
-	works, err := repo.FindAll()
+	works, err := repo.FindAll(context.Background())
 	if err != nil {
 		t.Fatalf("FindAll failed: %v", err)
 	}
@@ -95,10 +95,10 @@ func TestPgWorkRepository_CRUD(t *testing.T) {
 	}
 
 	// Delete
-	if err := repo.Delete(work.ID); err != nil {
+	if err := repo.Delete(context.Background(), work.ID); err != nil {
 		t.Fatalf("Delete failed: %v", err)
 	}
-	_, err = repo.FindByID(work.ID)
+	_, err = repo.FindByID(context.Background(), work.ID)
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound after delete, got %v", err)
 	}
@@ -109,14 +109,14 @@ func TestPgWorkRepository_Create_Conflict(t *testing.T) {
 
 	work := newPgTestWork("重複テスト")
 	t.Cleanup(func() {
-		_ = repo.Delete(work.ID)
+		_ = repo.Delete(context.Background(), work.ID)
 	})
 
-	if err := repo.Create(work); err != nil {
+	if err := repo.Create(context.Background(), work); err != nil {
 		t.Fatalf("first Create failed: %v", err)
 	}
 
-	err := repo.Create(work)
+	err := repo.Create(context.Background(), work)
 	if !errors.Is(err, repository.ErrConflict) {
 		t.Errorf("expected ErrConflict on duplicate insert, got %v", err)
 	}
@@ -125,7 +125,7 @@ func TestPgWorkRepository_Create_Conflict(t *testing.T) {
 func TestPgWorkRepository_FindByID_NotFound(t *testing.T) {
 	repo := setupPgWorkRepo(t)
 
-	_, err := repo.FindByID(uuid.New())
+	_, err := repo.FindByID(context.Background(), uuid.New())
 	if !errors.Is(err, repository.ErrNotFound) {
 		t.Errorf("expected ErrNotFound, got %v", err)
 	}

--- a/backend/internal/repository/step_repository.go
+++ b/backend/internal/repository/step_repository.go
@@ -3,25 +3,27 @@
 package repository
 
 import (
+	"context"
+
 	"github.com/akaitigo/urushi-chronicle/internal/domain"
 	"github.com/google/uuid"
 )
 
 // StepRepository defines the interface for process step persistence.
 type StepRepository interface {
-	Create(step *domain.ProcessStep) error
-	FindByID(workID, stepID uuid.UUID) (*domain.ProcessStep, error)
-	FindByWorkID(workID uuid.UUID) ([]domain.ProcessStep, error)
-	Update(step *domain.ProcessStep) error
-	Delete(workID, stepID uuid.UUID) error
-	DeleteByWorkID(workID uuid.UUID) error
+	Create(ctx context.Context, step *domain.ProcessStep) error
+	FindByID(ctx context.Context, workID, stepID uuid.UUID) (*domain.ProcessStep, error)
+	FindByWorkID(ctx context.Context, workID uuid.UUID) ([]domain.ProcessStep, error)
+	Update(ctx context.Context, step *domain.ProcessStep) error
+	Delete(ctx context.Context, workID, stepID uuid.UUID) error
+	DeleteByWorkID(ctx context.Context, workID uuid.UUID) error
 }
 
 // WorkRepository defines the interface for work persistence.
 type WorkRepository interface {
-	FindByID(id uuid.UUID) (*domain.Work, error)
-	FindAll() ([]domain.Work, error)
-	Create(work *domain.Work) error
-	Update(work *domain.Work) error
-	Delete(id uuid.UUID) error
+	FindByID(ctx context.Context, id uuid.UUID) (*domain.Work, error)
+	FindAll(ctx context.Context) ([]domain.Work, error)
+	Create(ctx context.Context, work *domain.Work) error
+	Update(ctx context.Context, work *domain.Work) error
+	Delete(ctx context.Context, id uuid.UUID) error
 }


### PR DESCRIPTION
## 概要

Go品質改善4件をまとめて対応する。

Fixes #24
Fixes #22
Fixes #26
Fixes #25

## 変更内容

### #22 全PGリポジトリがcontext.Background()ハードコード
- 4リポジトリインターフェース（Work / Step / Environment / AlertThreshold）の全メソッドに `context.Context` を第1引数として追加。
- PG実装は渡された `ctx` を使用（`context.Background()` ハードコードを除去）。memory実装はシグネチャを合わせる。
- ハンドラ層は `r.Context()` を伝播。monitor.Service.ProcessReading も `ctx` を受け取りDB操作へ伝播。
- これによりHTTPリクエストのキャンセル/デッドラインがDB操作まで伝わる。
- 全リポジトリ/ハンドラ/サービスのテスト呼び出しを更新。

### #24 graceful shutdown未実装
- `main.go` を `signal.NotifyContext` ベースへ移行（SIGINT/SIGTERM でコンテキストをキャンセル）。
- サーバのライフサイクルをテスト可能な `runServer(ctx, srv, timeout, logger)` に抽出。
- graceful shutdown のテストを追加（コンテキストキャンセルでクリーン終了 / 起動失敗時のエラー返却）。

### #26 deleteWorkでPGモード時にカスケードと明示削除が二重実行
- `PgWorkRepository.CascadesStepDeletion() bool` を追加（DBの `ON DELETE CASCADE` を宣言）。
- `deleteWork` はオプショナルインターフェースでカスケード可否を判定し、**PGモードでは明示的なstep削除をスキップ**（DBカスケードに委譲）。memoryモードは従来通り明示削除で整合性を維持。
- 両パスをテスト（memory=明示削除される / PG相当=スキップされる）。

### #25 .golangci.yml run.go "1.24" がgo.mod 1.25と不整合
- `run.go` を `1.25` に統一（`go.mod` の `go 1.25.0` と整合）。

## 検証
- `go build ./...` / `go test -race ./...` グリーン
- `golangci-lint run ./...` 0 issues
- `gofumpt -l .` 差分なし
- frontend vitest 59件パス（lefthook）
