### PR TITLE
ci(backend): PostgreSQL統合テストのCI実行・マイグレーションランナー追加 (#29 #28)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,25 @@ jobs:
     defaults:
       run:
         working-directory: backend
+    services:
+      # TimescaleDB (not plain postgres) is required: the schema uses the
+      # timescaledb extension and create_hypertable. This runs the PostgreSQL
+      # integration tests that are otherwise skipped when DATABASE_URL is unset.
+      postgres:
+        image: timescale/timescaledb:2.17.0-pg16
+        env:
+          POSTGRES_USER: urushi
+          POSTGRES_PASSWORD: urushi
+          POSTGRES_DB: urushi_chronicle
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U urushi -d urushi_chronicle"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+    env:
+      DATABASE_URL: postgres://urushi:urushi@localhost:5432/urushi_chronicle?sslmode=disable
     steps:
       - uses: actions/checkout@v7
 
@@ -25,6 +44,9 @@ jobs:
 
       - name: Build
         run: go build ./...
+
+      - name: Apply migrations
+        run: go run ./cmd/migrate
 
       - name: Test
         run: go test -v -race ./...

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint format check quality clean backend-check frontend-check
+.PHONY: build test lint format check quality clean backend-check frontend-check migrate
 
 build:
 	cd backend && go build ./...
@@ -18,6 +18,10 @@ format:
 
 check: lint test build
 	@echo "All checks passed."
+
+# Apply pending SQL migrations. Requires DATABASE_URL (e.g. source your .env first).
+migrate:
+	cd backend && go run ./cmd/migrate
 
 quality:
 	@echo "=== Quality Gate ==="

--- a/README.md
+++ b/README.md
@@ -26,10 +26,28 @@ cd backend && go mod download && go build ./...
 cd frontend && npm install && npm run dev
 ```
 
-> **注意**: `docker-entrypoint-initdb.d` にマウントされたマイグレーションSQLは、PostgreSQLの初回起動時のみ実行されます。スキーマを変更した場合は、既存のボリュームを削除してから再起動してください:
+## データベースマイグレーション
+
+スキーマは `backend/migrations/*.up.sql`（`NNN_説明.up.sql` 命名）で管理し、付属の
+マイグレーションランナーで適用する。`schema_migrations` テーブルで適用済みバージョンを
+追跡するため、`migrate` は冪等（未適用分のみ実行）。
+
+```bash
+# DATABASE_URL を設定して未適用のマイグレーションを適用する
+export DATABASE_URL=postgres://urushi:urushi@localhost:5432/urushi_chronicle?sslmode=disable
+make migrate
+# または直接:
+cd backend && go run ./cmd/migrate
+```
+
+環境変数:
+
+- `DATABASE_URL`（必須）: PostgreSQL接続文字列
+- `MIGRATIONS_DIR`（任意）: `*.up.sql` の配置ディレクトリ。デフォルト `migrations`
+
+> **注意**: `docker-entrypoint-initdb.d` にマウントされたマイグレーションSQLは、PostgreSQLの初回起動時のみ実行されます。以降のスキーマ変更は `make migrate` で適用してください。既存ボリュームを作り直す場合:
 > ```bash
-> docker compose down -v
-> docker compose up -d
+> docker compose down -v && docker compose up -d
 > ```
 
 ## 開発コマンド

--- a/backend/cmd/migrate/main.go
+++ b/backend/cmd/migrate/main.go
@@ -1,0 +1,59 @@
+// Command migrate applies pending SQL migrations from the migrations directory
+// to the database identified by DATABASE_URL.
+//
+// Usage:
+//
+//	DATABASE_URL=postgres://... go run ./cmd/migrate
+//
+// Environment variables:
+//
+//	DATABASE_URL    (required) PostgreSQL connection string.
+//	MIGRATIONS_DIR  (optional) path to *.up.sql files; defaults to "migrations".
+package main
+
+import (
+	"context"
+	"log"
+	"os"
+	"time"
+
+	"github.com/akaitigo/urushi-chronicle/internal/database"
+	"github.com/akaitigo/urushi-chronicle/internal/migrate"
+)
+
+func main() {
+	logger := log.New(os.Stdout, "[migrate] ", log.LstdFlags)
+
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		logger.Fatal("DATABASE_URL must be set")
+	}
+
+	dir := os.Getenv("MIGRATIONS_DIR")
+	if dir == "" {
+		dir = "migrations"
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	pool, err := database.NewPool(ctx, databaseURL)
+	if err != nil {
+		logger.Fatalf("failed to connect to database: %v", err)
+	}
+	defer pool.Close()
+
+	applied, err := migrate.Run(ctx, pool, dir)
+	if err != nil {
+		logger.Fatalf("migration failed: %v", err)
+	}
+
+	if len(applied) == 0 {
+		logger.Println("no pending migrations; schema is up to date")
+		return
+	}
+	for _, name := range applied {
+		logger.Printf("applied migration: %s", name)
+	}
+	logger.Printf("%d migration(s) applied", len(applied))
+}

--- a/backend/internal/migrate/migrate.go
+++ b/backend/internal/migrate/migrate.go
@@ -1,0 +1,152 @@
+// Package migrate provides a minimal, forward-only SQL migration runner.
+//
+// Migrations are plain .up.sql files named "NNN_description.up.sql" (matching the
+// golang-migrate convention already used in backend/migrations). Applied versions
+// are tracked in a schema_migrations table so Run is idempotent. This intentionally
+// avoids pulling in a heavyweight migration tool; see README for usage.
+package migrate
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// upSuffix identifies forward ("up") migration files.
+const upSuffix = ".up.sql"
+
+// migrationNamePattern constrains migration base names to digits, lowercase
+// letters, and underscores, so a recorded version can never contain unexpected input.
+var migrationNamePattern = regexp.MustCompile(`^[0-9]+_[a-z0-9_]+$`)
+
+// Migration is a single discovered up-migration.
+type Migration struct {
+	Version string // numeric prefix, e.g. "001"
+	Name    string // base name without .up.sql, e.g. "001_create_core_tables"
+	SQL     string
+}
+
+// Discover reads all *.up.sql files in dir, sorted lexicographically by file name.
+func Discover(dir string) ([]Migration, error) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read migrations dir %q: %w", dir, err)
+	}
+
+	var names []string
+	for _, e := range entries {
+		if e.IsDir() || !strings.HasSuffix(e.Name(), upSuffix) {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+
+	migrations := make([]Migration, 0, len(names))
+	for _, fileName := range names {
+		base := strings.TrimSuffix(fileName, upSuffix)
+		if !migrationNamePattern.MatchString(base) {
+			return nil, fmt.Errorf("invalid migration file name %q: must match NNN_name%s", fileName, upSuffix)
+		}
+		sqlBytes, err := os.ReadFile(filepath.Join(dir, fileName))
+		if err != nil {
+			return nil, fmt.Errorf("failed to read migration %q: %w", fileName, err)
+		}
+		migrations = append(migrations, Migration{
+			Version: base[:strings.IndexByte(base, '_')],
+			Name:    base,
+			SQL:     string(sqlBytes),
+		})
+	}
+	return migrations, nil
+}
+
+// Run applies all pending migrations from dir against pool and returns the names
+// of migrations that were applied (empty when the schema is already up to date).
+func Run(ctx context.Context, pool *pgxpool.Pool, dir string) ([]string, error) {
+	if _, err := pool.Exec(ctx, `
+		CREATE TABLE IF NOT EXISTS schema_migrations (
+			version    TEXT PRIMARY KEY,
+			name       TEXT NOT NULL,
+			applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+		)
+	`); err != nil {
+		return nil, fmt.Errorf("failed to ensure schema_migrations table: %w", err)
+	}
+
+	applied, err := appliedVersions(ctx, pool)
+	if err != nil {
+		return nil, err
+	}
+
+	migrations, err := Discover(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	var ran []string
+	for _, m := range migrations {
+		if applied[m.Version] {
+			continue
+		}
+		if err := apply(ctx, pool, m); err != nil {
+			return ran, fmt.Errorf("failed to apply migration %s: %w", m.Name, err)
+		}
+		ran = append(ran, m.Name)
+	}
+	return ran, nil
+}
+
+// appliedVersions returns the set of migration versions already recorded.
+func appliedVersions(ctx context.Context, pool *pgxpool.Pool) (map[string]bool, error) {
+	rows, err := pool.Query(ctx, `SELECT version FROM schema_migrations`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query applied migrations: %w", err)
+	}
+	defer rows.Close()
+
+	applied := make(map[string]bool)
+	for rows.Next() {
+		var v string
+		if err := rows.Scan(&v); err != nil {
+			return nil, fmt.Errorf("failed to scan applied migration: %w", err)
+		}
+		applied[v] = true
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("error iterating applied migrations: %w", err)
+	}
+	return applied, nil
+}
+
+// apply executes a single migration's SQL, then records it.
+//
+// The SQL may contain multiple statements, so it is run via the simple query
+// protocol (PgConn.Exec), which implicitly wraps a statement-only file in one
+// transaction. The version/name are recorded with a parameterized INSERT.
+func apply(ctx context.Context, pool *pgxpool.Pool, m Migration) error {
+	conn, err := pool.Acquire(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to acquire connection: %w", err)
+	}
+	defer conn.Release()
+
+	if _, err := conn.Conn().PgConn().Exec(ctx, m.SQL).ReadAll(); err != nil {
+		return fmt.Errorf("failed to execute migration SQL: %w", err)
+	}
+
+	if _, err := conn.Exec(
+		ctx,
+		`INSERT INTO schema_migrations (version, name) VALUES ($1, $2)`,
+		m.Version, m.Name,
+	); err != nil {
+		return fmt.Errorf("failed to record applied migration: %w", err)
+	}
+	return nil
+}

--- a/backend/internal/migrate/migrate_test.go
+++ b/backend/internal/migrate/migrate_test.go
@@ -1,0 +1,129 @@
+package migrate_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/akaitigo/urushi-chronicle/internal/migrate"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func writeFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestDiscover_SortsAndFiltersUpFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Intentionally out of order, plus non-migration files that must be ignored.
+	writeFile(t, dir, "002_add_index.up.sql", "SELECT 2;")
+	writeFile(t, dir, "001_create_core_tables.up.sql", "SELECT 1;")
+	writeFile(t, dir, "001_create_core_tables.down.sql", "DROP;")
+	writeFile(t, dir, "README.md", "docs")
+
+	migrations, err := migrate.Discover(dir)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(migrations) != 2 {
+		t.Fatalf("expected 2 up-migrations, got %d", len(migrations))
+	}
+	if migrations[0].Version != "001" || migrations[0].Name != "001_create_core_tables" {
+		t.Errorf("first migration = %+v, want version 001", migrations[0])
+	}
+	if migrations[1].Version != "002" || migrations[1].Name != "002_add_index" {
+		t.Errorf("second migration = %+v, want version 002", migrations[1])
+	}
+	if migrations[0].SQL != "SELECT 1;" {
+		t.Errorf("unexpected SQL for first migration: %q", migrations[0].SQL)
+	}
+}
+
+func TestDiscover_RejectsInvalidName(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "not-a-valid-name.up.sql", "SELECT 1;")
+
+	if _, err := migrate.Discover(dir); err == nil {
+		t.Error("expected error for invalid migration file name")
+	}
+}
+
+func TestDiscover_MissingDir(t *testing.T) {
+	if _, err := migrate.Discover(filepath.Join(t.TempDir(), "does-not-exist")); err == nil {
+		t.Error("expected error for missing migrations dir")
+	}
+}
+
+func TestDiscover_EmptyDir(t *testing.T) {
+	migrations, err := migrate.Discover(t.TempDir())
+	if err != nil {
+		t.Fatalf("Discover on empty dir: %v", err)
+	}
+	if len(migrations) != 0 {
+		t.Errorf("expected 0 migrations, got %d", len(migrations))
+	}
+}
+
+// TestRun_Integration exercises the runner against a real database. It is skipped
+// unless DATABASE_URL is set (e.g. in CI). It uses a high version number and
+// cleans up after itself so it never collides with the application's migrations.
+func TestRun_Integration(t *testing.T) {
+	databaseURL := os.Getenv("DATABASE_URL")
+	if databaseURL == "" {
+		t.Skip("DATABASE_URL not set; skipping migration integration test")
+	}
+
+	ctx := context.Background()
+	pool, err := pgxpool.New(ctx, databaseURL)
+	if err != nil {
+		t.Skipf("failed to create pool (DB not available): %v", err)
+	}
+	if err := pool.Ping(ctx); err != nil {
+		pool.Close()
+		t.Skipf("failed to ping database (DB not available): %v", err)
+	}
+	t.Cleanup(func() { pool.Close() })
+
+	t.Cleanup(func() {
+		_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS migrate_selftest")
+		_, _ = pool.Exec(ctx, "DELETE FROM schema_migrations WHERE version = '900'")
+	})
+	// Start clean in case a previous failed run left artifacts.
+	_, _ = pool.Exec(ctx, "DROP TABLE IF EXISTS migrate_selftest")
+	_, _ = pool.Exec(ctx, "DELETE FROM schema_migrations WHERE version = '900'")
+
+	dir := t.TempDir()
+	writeFile(t, dir, "900_migrate_selftest.up.sql",
+		"CREATE TABLE migrate_selftest (id INT PRIMARY KEY);\nINSERT INTO migrate_selftest (id) VALUES (1);")
+
+	// First run applies the migration.
+	applied, err := migrate.Run(ctx, pool, dir)
+	if err != nil {
+		t.Fatalf("Run (first): %v", err)
+	}
+	if len(applied) != 1 || applied[0] != "900_migrate_selftest" {
+		t.Fatalf("expected [900_migrate_selftest] applied, got %v", applied)
+	}
+
+	// The table and its row must exist (proves the multi-statement SQL ran).
+	var count int
+	if err := pool.QueryRow(ctx, "SELECT count(*) FROM migrate_selftest").Scan(&count); err != nil {
+		t.Fatalf("query migrate_selftest: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("expected 1 row in migrate_selftest, got %d", count)
+	}
+
+	// Second run is a no-op (idempotent).
+	appliedAgain, err := migrate.Run(ctx, pool, dir)
+	if err != nil {
+		t.Fatalf("Run (second): %v", err)
+	}
+	if len(appliedAgain) != 0 {
+		t.Errorf("expected no migrations on second run, got %v", appliedAgain)
+	}
+}


### PR DESCRIPTION
## 概要

テスト/CI整備2件をまとめて対応する。

Fixes #29
Fixes #28

## 変更内容

### #28 マイグレーションランナー不在
- `internal/migrate` パッケージと `cmd/migrate` を追加。`backend/migrations/*.up.sql`（`NNN_説明.up.sql` 命名）を順次適用する。
- `schema_migrations` テーブルで適用済みバージョンを追跡 → **冪等**（未適用分のみ実行）。
- マルチステートメントSQLは pgconn の simple query protocol で実行（暗黙トランザクションで原子的）。適用記録はパラメータバインドのINSERT。
- ファイル名は `^[0-9]+_[a-z0-9_]+$` で検証。
- `make migrate` ターゲット + README にマイグレーション手順を記載。
- テスト: `Discover`（ソート/フィルタ/命名検証/空ディレクトリ）+ 実DB統合テスト（`DATABASE_URL` 未設定時はskip、version 900の一時マイグレーションで自己完結・自己クリーンアップ）。

### #29 PostgreSQLインテグレーションテストのCI組込み
- `ci.yml` の backend ジョブに **timescaledb サービスコンテナ**（`timescale/timescaledb:2.17.0-pg16`）を追加。スキーマが `timescaledb` 拡張と `create_hypertable` を使うため plain postgres ではなく timescaledb イメージが必須。
- ジョブに `DATABASE_URL` を設定し、`go run ./cmd/migrate` でスキーマ適用後に `go test -race ./...` を実行。
- これまで `DATABASE_URL` 未設定でskipされていたPGインテグレーションテスト（pg_work / pg_step / pg_environment / pg_alert_threshold）がCIで**実際に実行**される。
- GitHub Actions無料枠内（サービスコンテナは追加課金なし）。

## 検証
- ローカルで `timescale/timescaledb:2.17.0-pg16` コンテナを起動し、CIと同じ経路を実証:
  - `go run ./cmd/migrate` で全6テーブル作成（hypertable含む）、2回目実行は冪等でno-op
  - `DATABASE_URL` 付き `go test -race ./...` で全PGインテグレーションテスト + migrate統合テストがPASS（skipなし）
- `DATABASE_URL` 未設定時は統合テストが正しくskipされることも確認
- `actionlint` パス / `golangci-lint` 0 issues / `gofumpt -l` 差分なし / frontend vitest 59件パス
